### PR TITLE
Return one set of constraints per boundary

### DIFF
--- a/src/Collocation/Collocation.jl
+++ b/src/Collocation/Collocation.jl
@@ -88,7 +88,7 @@ function collocation_points!(::AvgKnots, x, B::AbstractBSplineBasis)
 
     # For recombined bases, skip points at the boundaries.
     # Note that j = 0 for non-recombined bases, i.e. boundaries are included.
-    j = num_constraints(B)
+    j, _ = num_constraints(B)
 
     v::T = inv(k - 1)
     a::T, b::T = boundaries(B)

--- a/src/Galerkin/linear.jl
+++ b/src/Galerkin/linear.jl
@@ -137,11 +137,11 @@ function allocate_galerkin_matrix(
     bands = if symmetry
         (0, Nb)
     else
-        # If the bases have different lengths (⇔ δ ≠ 0), then the bands are
-        # shifted.
-        δ = num_constraints(B2) - num_constraints(B1)
-        @assert N1 == N2 + 2δ
-        (Nb + δ, Nb - δ)
+        # If the bases have different number of constraints (BCs) on the left
+        # boundary (⇔ δl ≠ 0), then the bands are shifted.
+        δl, δr = num_constraints(B2) .- num_constraints(B1)
+        @assert N1 == N2 + δl + δr
+        (Nb + δl, Nb - δl)
     end
     M(undef, (N1, N2), bands)
 end
@@ -204,11 +204,11 @@ function galerkin_matrix!(S::AbstractMatrix, Bs::NTuple{2,AbstractBSplineBasis},
     end
 
     # Number of BCs on each boundary
-    δ = num_constraints(B2) - num_constraints(B1)
-    @assert M + 2δ == N
+    δl, δr = num_constraints(B2) .- num_constraints(B1)
+    @assert M + δl + δr == N
 
     for j = 1:M
-        i0 = j + δ
+        i0 = j + δl
         tj = support(B2, j)
         fj = x -> evaluate(B2, j, x, deriv[2])
         istart = fill_upper ? 1 : i0

--- a/src/Galerkin/quadratic.jl
+++ b/src/Galerkin/quadratic.jl
@@ -27,8 +27,8 @@ function galerkin_tensor(
     if length(Bs[1]) != length(Bs[2])
         throw(ArgumentError("the first two bases must have the same lengths"))
     end
-    δ = num_constraints(Bs[3]) - num_constraints(Bs[1])
-    A = BandedTensor3D{T}(undef, dims, Val(b), bandshift=(0, 0, δ))
+    δl, δr = num_constraints(Bs[3]) .- num_constraints(Bs[1])
+    A = BandedTensor3D{T}(undef, dims, Val(b), bandshift=(0, 0, δl))
     galerkin_tensor!(A, Bs, deriv)
 end
 
@@ -72,18 +72,18 @@ function galerkin_tensor!(A::BandedTensor3D,
     quad = _quadrature_prod(3k - 3)
 
     Al = Matrix{T}(undef, 2k - 1, 2k - 1)
-    δ = num_constraints(Bl) - num_constraints(Bi)
-    @assert Ni == Nj == Nl + 2δ
+    δl, δr = num_constraints(Bl) .- num_constraints(Bi)
+    @assert Ni == Nj == Nl + δl + δr
 
     if bandwidth(A) != k - 1
         throw(ArgumentError("BandedTensor3D must have bandwidth = $(k - 1)"))
     end
-    if bandshift(A) != (0, 0, δ)
-        throw(ArgumentError("BandedTensor3D must have bandshift = (0, 0, $δ)"))
+    if bandshift(A) != (0, 0, δl)
+        throw(ArgumentError("BandedTensor3D must have bandshift = (0, 0, $δl)"))
     end
 
     for l = 1:Nl
-        ll = l + δ
+        ll = l + δl
         istart = clamp(ll - h, 1, Ni)
         iend = clamp(ll + h, 1, Nj)
         is = istart:iend

--- a/src/Recombinations/matrices.jl
+++ b/src/Recombinations/matrices.jl
@@ -263,7 +263,6 @@ _max_order(A::RecombineMatrix) = map(ops -> max_order(ops...), constraints(A))
 # near each boundary.
 # For instance, Neumann BCs have a single recombined function, ϕ_1 = b_1 + b_2;
 # while mixed Dirichlet + Neumann have none, ϕ_1 = b_3.
-# TODO store result of this in RecombineMatrix...
 num_recombined(A::RecombineMatrix) =
     map((m, c) -> m + 1 - c, _max_order(A), num_constraints(A))
 num_recombined(::UniformScaling) = (0, 0)

--- a/src/Recombinations/matrices.jl
+++ b/src/Recombinations/matrices.jl
@@ -249,26 +249,33 @@ RecombineMatrix(ops::Tuple{Vararg{AbstractDifferentialOp}}, args...) =
         "boundary condition combination is currently unsupported: $ops"))
 
 Base.size(A::RecombineMatrix) = (A.N, A.M)
-constraints(A::RecombineMatrix) = A.ops
-num_constraints(A::RecombineMatrix) = length(constraints(A))
-num_constraints(::UniformScaling) = 0  # case of non-recombined bases
 
-DifferentialOps.max_order(A::RecombineMatrix) = max_order(constraints(A)...)
+constraints(A::RecombineMatrix) = (A.ops, A.ops)
+constraints(::UniformScaling) = ((), ())
+
+num_constraints(A::RecombineMatrix) = map(length, constraints(A))
+num_constraints(::UniformScaling) = (0, 0)  # case of non-recombined bases
+
+# Returns (left, right) tuple with maximum BC order on each boundary.
+_max_order(A::RecombineMatrix) = map(ops -> max_order(ops...), constraints(A))
 
 # Returns number of basis functions that are recombined from the original basis
 # near each boundary.
 # For instance, Neumann BCs have a single recombined function, ϕ_1 = b_1 + b_2;
 # while mixed Dirichlet + Neumann have none, ϕ_1 = b_3.
-num_recombined(A::RecombineMatrix) = max_order(A) + 1 - num_constraints(A)
+# TODO store result of this in RecombineMatrix...
+num_recombined(A::RecombineMatrix) =
+    map((m, c) -> m + 1 - c, _max_order(A), num_constraints(A))
+num_recombined(::UniformScaling) = (0, 0)
 
 # j: index in recombined basis
 # M: length of recombined basis
 @inline function which_recombine_block(A::RecombineMatrix, j)
     @boundscheck checkbounds(A, :, j)
     M = A.M
-    n = num_recombined(A)
-    j <= n && return 1
-    j > M - n && return 3
+    nl, nr = num_recombined(A)  # left/right number of recombined bases
+    j <= nl && return 1
+    j > M - nr && return 3
     2
 end
 
@@ -280,7 +287,7 @@ Returns the range of row indices `i` such that `A[i, col]` is non-zero.
 @propagate_inbounds function nzrows(A::RecombineMatrix,
                                     j::Integer) :: UnitRange{Int}
     block = which_recombine_block(A, j)
-    j += num_constraints(A)
+    j += num_constraints(A)[1]
     if block == 1
         (j - 1):j
     elseif block == 2
@@ -301,9 +308,10 @@ end
     T = eltype(A)
     @inbounds block = which_recombine_block(A, j)
 
+    cl, cr = num_constraints(A)  # left/right constraints
+
     if block == 2
-        c = num_constraints(A)
-        return T(i == j + c)  # δ_{i, j+c}
+        return T(i == j + cl)  # δ_{i, j+c}
     end
 
     if block == 1
@@ -316,12 +324,12 @@ end
 
     # The lower-right corner starts at column h + 1.
     M = size(A, 2)
-    n = num_recombined(A)
-    h = M - n
+    nl, nr = num_recombined(A)
+    h = M - nr
 
     @assert j > h
     C = A.lr
-    ii = i - h - num_constraints(A)
+    ii = i - h - cr
     if ii ∈ axes(C, 1)
         return @inbounds C[ii, j - h] :: T
     end
@@ -336,18 +344,18 @@ function LinearAlgebra.mul!(y::AbstractVector, A::RecombineMatrix,
     checkdims_mul(y, A, x)
     N, M = size(A)
 
-    n = num_recombined(A)
-    c = num_constraints(A)
-    n1 = n + c
-    h = M - n
+    nl, nr = num_recombined(A)
+    cl, cr = num_constraints(A)
+    n1 = nl + cl
+    h = M - nr
 
-    @inbounds y[1:n1] = A.ul * @view x[1:n]
+    @inbounds y[1:n1] = A.ul * @view x[1:nl]
 
-    for i = (n + 1):h
-        @inbounds y[i + c] = x[i]
+    for i = (nl + 1):h
+        @inbounds y[i + cl] = x[i]
     end
 
-    @inbounds y[(N - n - c + 1):N] = A.lr * @view x[(h + 1):M]
+    @inbounds y[(N - nr - cr + 1):N] = A.lr * @view x[(h + 1):M]
 
     y
 end
@@ -361,18 +369,18 @@ function LinearAlgebra.mul!(y::AbstractVector, A::RecombineMatrix,
     checkdims_mul(y, A, x)
     N, M = size(A)
 
-    n = num_recombined(A)
-    c = num_constraints(A)
-    n1 = n + c
-    h = M - n
+    nl, nr = num_recombined(A)
+    cl, cr = num_constraints(A)
+    n1 = nl + cl
+    h = M - nr
 
-    @inbounds y[1:n1] = α * A.ul * view(x, 1:n) + β * SVector{n1}(view(y, 1:n1))
+    @inbounds y[1:n1] = α * A.ul * view(x, 1:nl) + β * SVector{n1}(view(y, 1:n1))
 
-    for i = (n + 1):h
-        @inbounds y[i + c] = α * x[i] + β * y[i + c]
+    for i = (nl + 1):h
+        @inbounds y[i + cl] = α * x[i] + β * y[i + cl]
     end
 
-    js = (N - n - c + 1):N
+    js = (N - nr - cr + 1):N
     @inbounds y[js] =
         α * A.lr * view(x, (h + 1):M) + β * SVector{n1}(view(y, js))
 
@@ -384,18 +392,18 @@ function LinearAlgebra.ldiv!(x::AbstractVector, A::RecombineMatrix,
     checkdims_mul(y, A, x)
     N, M = size(A)
 
-    n = num_recombined(A)
-    c = num_constraints(A)
-    n1 = n + c
-    h = M - n
+    nl, nr = num_recombined(A)
+    cl, cr = num_constraints(A)
+    n1 = nl + cl
+    h = M - nr
 
-    @inbounds x[1:n] = _ldiv_unique_solution(A.ul, view(y, 1:n1))
+    @inbounds x[1:nl] = _ldiv_unique_solution(A.ul, view(y, 1:n1))
 
-    for i = (n + 1):h
-        @inbounds x[i] = y[i + c]
+    for i = (nl + 1):h
+        @inbounds x[i] = y[i + cl]
     end
 
-    js = (N - n - c + 1):N
+    js = (N - nr - cr + 1):N
     @inbounds x[(h + 1):M] = _ldiv_unique_solution(A.lr, view(y, js))
 
     x

--- a/test/recombination.jl
+++ b/test/recombination.jl
@@ -19,13 +19,17 @@ function test_nzrows(A::RecombineMatrix)
 end
 
 function test_recombine_matrix(A::RecombineMatrix)
-    @testset "Recombination matrix: $(constraints(A))" begin
+    bcleft, bcright = constraints(A)
+    @assert bcleft === bcright  # only supported case for now
+    @testset "Recombination matrix: $(bcleft)" begin
         test_nzrows(A)
         N, M = size(A)
-        @test M == N - 2 * num_constraints(A)
-
-        n = num_recombined(A)
-        c = num_constraints(A)
+        nl, nr = num_recombined(A)
+        cl, cr = num_constraints(A)
+        @assert nl == nr && cl == cr  # only supported case for now
+        n = nl
+        c = cl
+        @test M == N - sum(num_constraints(A))
 
         # The sum of all rows is 2 in the recombined regions (because 2
         # recombined B-splines), and 1 in the centre.
@@ -72,12 +76,13 @@ function test_recombine_matrix(A::RecombineMatrix)
 end
 
 test_boundary_conditions(R::RecombinedBSplineBasis) =
-    test_boundary_conditions(constraints(R), R)
+    test_boundary_conditions(constraints(R)[1], R)
 
 function test_boundary_conditions(ops::Tuple{Vararg{Derivative}},
                                   R::RecombinedBSplineBasis)
-    @assert ops === constraints(R)
-    @test length(ops) == num_constraints(R)
+    # TODO this won't work if R has different BCs on the left and right boundaries
+    @assert (ops, ops) === constraints(R)
+    @test length(ops) == num_constraints(R)[1] == num_constraints(R)[2]
     @test length(R) == length(parent(R)) - 2 * length(ops)
 
     a, b = boundaries(R)
@@ -109,7 +114,7 @@ function test_boundary_conditions(ops::Tuple{Vararg{Derivative}},
         # derivative at the border of the first B-spline of the original
         # basis.
         B = parent(R)
-        ε = 2 * num_recombined(R) * eps(B[1](a, Derivative(n)))
+        ε = 2 * num_recombined(R)[1] * eps(B[1](a, Derivative(n)))
         if Derivative(n) ∈ ops
             @test bsum ≤ ε
         else
@@ -122,8 +127,8 @@ end
 
 # More general BCs (Robin-like BCs and more combinations).
 function test_boundary_conditions(ops, R::RecombinedBSplineBasis)
-    @assert ops === constraints(R)
-    @test length(ops) == num_constraints(R)
+    @assert (ops, ops) === constraints(R)
+    @test length(ops) == num_constraints(R)[1] == num_constraints(R)[2]
     @test length(R) == length(parent(R)) - 2 * length(ops)
 
     a, b = boundaries(R)
@@ -138,7 +143,7 @@ function test_boundary_conditions(ops, R::RecombinedBSplineBasis)
             abs(fa) + abs(fb)
         end
         B = parent(R)
-        ε = 2 * num_recombined(R) * eps(B[1](a, op_a))
+        ε = 2 * num_recombined(R)[1] * eps(B[1](a, op_a))
         @test bsum ≤ ε
     end
 
@@ -150,7 +155,7 @@ function test_basis_recombination()
     knots_base = gauss_lobatto_points(40)
     k = 4
     B = BSplineBasis(k, knots_base)
-    @test constraints(B) === ()
+    @test constraints(B) === ((), ())
     @testset "Mixed derivatives" begin
         @inferred RecombineMatrix(Derivative.((0, 1)), B)
         @inferred RecombineMatrix(Derivative.((0, 2)), B)
@@ -169,15 +174,17 @@ function test_basis_recombination()
 
     @testset "Order $D" for D = 0:(k - 1)
         R = RecombinedBSplineBasis(Derivative(D), B)
-        @test constraints(R) === (Derivative(D), )
+        ops = (Derivative(D), )
+        @test constraints(R) === (ops, ops)
         test_recombine_matrix(recombination_matrix(R))
         test_boundary_conditions(R)
 
         let
             N = length(R)
             a, b = boundaries(R)
+            cl, cr = constraints(R)
             @test string(R) ==
-                "$N-element RecombinedBSplineBasis: order $k, domain [$a, $b], BCs (D{$D},)"
+            "$N-element RecombinedBSplineBasis: order $k, domain [$a, $b], BCs {left => $cl, right => $cr}"
         end
 
         @testset "Robin-like BCs" begin
@@ -188,7 +195,7 @@ function test_basis_recombination()
                 @test_throws ArgumentError RecombinedBSplineBasis(op, B)
             else
                 let Rs = RecombinedBSplineBasis(op, B)
-                    @test constraints(Rs) === (op, )
+                    @test constraints(Rs) === ((op, ), (op, ))
                     test_recombine_matrix(recombination_matrix(Rs))
                     test_boundary_conditions(Rs)
                 end
@@ -196,7 +203,7 @@ function test_basis_recombination()
                     # Combine with Dirichlet BCs
                     ops = (Derivative(0), op)
                     Rs = RecombinedBSplineBasis(ops, B)
-                    @test constraints(Rs) === ops
+                    @test constraints(Rs) === (ops, ops)
                     test_recombine_matrix(recombination_matrix(Rs))
                     test_boundary_conditions(Rs)
                 end
@@ -207,7 +214,7 @@ function test_basis_recombination()
         @testset "Mixed BCs" begin
             ops = ntuple(d -> Derivative(d - 1), D + 1)
             Rs = RecombinedBSplineBasis(ops, B)
-            @test constraints(Rs) === ntuple(n -> Derivative(n - 1), D + 1)
+            @test constraints(Rs) === (ops, ops)
             test_recombine_matrix(recombination_matrix(Rs))
             test_boundary_conditions(Rs)
         end

--- a/test/recombination.jl
+++ b/test/recombination.jl
@@ -75,12 +75,15 @@ function test_recombine_matrix(A::RecombineMatrix)
     nothing
 end
 
-test_boundary_conditions(R::RecombinedBSplineBasis) =
-    test_boundary_conditions(constraints(R)[1], R)
+function test_boundary_conditions(R::RecombinedBSplineBasis)
+    bl, br = constraints(R)
+    @assert bl === br "different BCs on each boundary not yet supported"
+    test_boundary_conditions(bl, R)
+end
 
 function test_boundary_conditions(ops::Tuple{Vararg{Derivative}},
                                   R::RecombinedBSplineBasis)
-    # TODO this won't work if R has different BCs on the left and right boundaries
+    # TODO adapt this for different BCs on the left and right boundaries
     @assert (ops, ops) === constraints(R)
     @test length(ops) == num_constraints(R)[1] == num_constraints(R)[2]
     @test length(R) == length(parent(R)) - 2 * length(ops)


### PR DESCRIPTION
`constraints` now returns two sets of boundary conditions, `(ops_left, ops_right)`, to be applied on the left and right boundaries.

At the moment both returned sets are identical, as imposing different BCs on each boundary is not yet supported. But this change will enable such behaviour in the future.