### PR TITLE
Faster LU factorisation of collocation matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         experimental: [false]
         version:
-          - '1.4'
           - '1.5'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Juan Ignacio Polanco <jipolanc@gmail.com>"]
 version = "0.4.0"
 
 [deps]
+ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,6 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+ArrayLayouts = "0.5"
 BandedMatrices = "0.15, 0.16"
 FastGaussQuadrature = "0.4"
 Reexport = "0.2, 1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSplineKit"
 uuid = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com>"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -15,8 +15,8 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 ArrayLayouts = "0.5"
-BandedMatrices = "0.15, 0.16"
+BandedMatrices = "0.16"
 FastGaussQuadrature = "0.4"
-Reexport = "0.2, 1.0"
-StaticArrays = "0.12, 1.0"
-julia = "1.4"
+Reexport = "1.0"
+StaticArrays = "1.0"
+julia = "1.5"

--- a/docs/src/collocation.md
+++ b/docs/src/collocation.md
@@ -21,6 +21,9 @@ AvgKnots
 ## Matrices
 
 ```@docs
+CollocationMatrix
 collocation_matrix
 collocation_matrix!
+lu
+lu!
 ```

--- a/src/Collocation/Collocation.jl
+++ b/src/Collocation/Collocation.jl
@@ -158,8 +158,7 @@ artificially increase the number of elements (and sometimes the bandwidth) of
 the matrix.
 They may appear when a collocation point is located on a knot.
 By default, `clip_threshold` is set to the machine epsilon associated to the
-matrix element type (see
-[`eps`](https://docs.julialang.org/en/v1/base/base/#Base.eps-Tuple{Type{var%22#s23%22}%20where%20var%22#s23%22%3C:AbstractFloat})).
+matrix element type (see `eps` in the Julia documentation).
 Set it to zero to disable this behaviour.
 
 ## Matrix types

--- a/src/Collocation/matrix.jl
+++ b/src/Collocation/matrix.jl
@@ -101,14 +101,15 @@ function lu!(C::CollocationMatrix, _pivot_IGNORED = Val(false); check = true)
     middle = nbandu + 1  # w[middle, :] contains the main diagonal of A
     Cfact = LU(C, Int[], 0) :: CollocationLU  # factors, ipiv, info
 
-    @inbounds if nrow == 1 && iszero(w[middle, nrow])
-        throw(ZeroPivotException(1))
+    if nrow == 1
+        @inbounds iszero(w[middle, nrow]) && throw(ZeroPivotException(1))
+        return Cfact
     end
 
     if nbandl == 0
         # A is upper triangular. Check that the diagonal is nonzero.
-        @inbounds for i = 1:nrow
-            iszero(w[middle, i]) && throw(ZeroPivotException(i))
+        for i = 1:nrow
+            @inbounds iszero(w[middle, i]) && throw(ZeroPivotException(i))
         end
         return Cfact
     end
@@ -149,9 +150,7 @@ function lu!(C::CollocationMatrix, _pivot_IGNORED = Val(false); check = true)
     end
 
     # Check the last diagonal entry.
-    @inbounds if iszero(w[middle, nrow])
-        throw(ZeroPivotException(nrow))
-    end
+    @inbounds iszero(w[middle, nrow]) && throw(ZeroPivotException(nrow))
 
     Cfact
 end

--- a/src/Collocation/matrix.jl
+++ b/src/Collocation/matrix.jl
@@ -32,7 +32,8 @@ positivity of spline collocation matrices (de Boor 2001, p. 175).
 well as out-of-place factorisation using [`lu`](@ref). LU decomposition may also
 be performed via `factorize`.
 
-!!! warning This type only supports **square** collocation matrices.
+!!! warning "Matrix shape"
+    This type only supports **square** collocation matrices.
 
 """
 struct CollocationMatrix{
@@ -76,12 +77,17 @@ end
 
 const CollocationLU{T} = LU{T, <:CollocationMatrix{T}} where {T}
 
-# In-place LU factorisation without pivoting of banded matrix.
-# Takes advantage of the totally positive property of collocation matrices
-# appearing in spline calculations (de Boor 1978).
-# The code is ported from Carl de Boor's BANFAC routine in FORTRAN77, via its
-# FORTRAN90 version by John Burkardt.
-# Note that this only works for square matrices!!
+"""
+    LinearAlgebra.lu!(C::CollocationMatrix, pivot = Val(false); check = true)
+
+Perform in-place LU factorisation of collocation matrix without pivoting.
+
+Takes advantage of the totally positive property of collocation matrices
+appearing in spline calculations (de Boor 1978).
+
+The code is ported from Carl de Boor's BANFAC routine in FORTRAN77, via its
+[FORTRAN90 version by John Burkardt](https://people.sc.fsu.edu/~jburkardt/f_src/pppack/pppack.f90).
+"""
 function lu!(C::CollocationMatrix, _pivot_IGNORED = Val(false); check = true)
     check || throw(ArgumentError("`check = false` not yet supported"))
     w = bandeddata(C)
@@ -150,6 +156,13 @@ function lu!(C::CollocationMatrix, _pivot_IGNORED = Val(false); check = true)
     Cfact
 end
 
+"""
+    LinearAlgebra.lu(C::CollocationMatrix, pivot = Val(false); check = true)
+
+Returns LU factorisation of collocation matrix.
+
+See also [`lu!`](@ref).
+"""
 lu(C::CollocationMatrix, args...; kws...) = lu!(copy(C), args...; kws...)
 
 ldiv!(F::CollocationLU, y::AbstractVector) = ldiv!(y, F, y)

--- a/src/Collocation/matrix.jl
+++ b/src/Collocation/matrix.jl
@@ -1,0 +1,238 @@
+using ArrayLayouts: MemoryLayout
+using BandedMatrices
+
+import BandedMatrices:
+    AbstractBandedMatrix, bandwidths, bandeddata
+
+using LinearAlgebra
+import LinearAlgebra:
+    LU, ZeroPivotException,
+    ldiv!, lu!, lu, factorize
+
+import Base: @propagate_inbounds
+
+"""
+    CollocationMatrix{T} <: AbstractBandedMatrix{T}
+
+B-spline collocation matrix, defined by
+
+```math
+C_{ij} = b_j(x_i),
+```
+
+where ``\\bm{x}`` is a set of collocation points.
+
+Wraps a `BandedMatrix`, providing an efficient LU factorisation without pivoting
+adapted from de Boor (1978). The factorisation takes advantage of the total
+positivity of spline collocation matrices (de Boor 2001, p. 175).
+
+# Factorisation
+
+`CollocationMatrix` supports in-place LU factorisation using [`lu!`](@ref), as
+well as out-of-place factorisation using [`lu`](@ref). LU decomposition may also
+be performed via `factorize`.
+
+!!! warning This type only supports **square** collocation matrices.
+
+"""
+struct CollocationMatrix{
+        T,
+        M <: BandedMatrix{T},
+    } <: AbstractBandedMatrix{T}
+
+    data :: M
+
+    function CollocationMatrix(x::BandedMatrix{T}) where {T}
+        size(x, 1) == size(x, 2) ||
+            throw(DimensionMismatch("CollocationMatrix must be square"))
+        new{T, typeof(x)}(x)
+    end
+end
+
+# This affects printing e.g. in the REPL.
+MemoryLayout(::Type{<:CollocationMatrix{T,M}}) where {T,M} = MemoryLayout(M)
+
+factorize(A::CollocationMatrix) = lu(A)
+bandwidths(A::CollocationMatrix) = bandwidths(parent(A))
+bandeddata(A::CollocationMatrix) = bandeddata(parent(A))
+
+Base.parent(A::CollocationMatrix) = A.data
+Base.size(A::CollocationMatrix) = size(parent(A))
+Base.copy(A::CollocationMatrix) = CollocationMatrix(copy(parent(A)))
+
+# Adapted from BandedMatrices
+function Base.array_summary(
+        io::IO, A::CollocationMatrix, inds::Tuple{Vararg{Base.OneTo}},
+    )
+    T = eltype(A)
+    print(io, Base.dims2string(length.(inds)), " CollocationMatrix{$T} with bandwidths $(bandwidths(A))")
+end
+
+@inline @propagate_inbounds Base.getindex(A::CollocationMatrix, i...) =
+    parent(A)[i...]
+
+@inline @propagate_inbounds Base.setindex!(A::CollocationMatrix, v, i...) =
+    parent(A)[i...] = v
+
+const CollocationLU{T} = LU{T, <:CollocationMatrix{T}} where {T}
+
+# In-place LU factorisation without pivoting of banded matrix.
+# Takes advantage of the totally positive property of collocation matrices
+# appearing in spline calculations (de Boor 1978).
+# The code is ported from Carl de Boor's BANFAC routine in FORTRAN77, via its
+# FORTRAN90 version by John Burkardt.
+# Note that this only works for square matrices!!
+function lu!(C::CollocationMatrix, _pivot_IGNORED = Val(false); check = true)
+    check || throw(ArgumentError("`check = false` not yet supported"))
+    w = bandeddata(C)
+    nbandl, nbandu = bandwidths(C)
+    nrow = size(C, 1)
+    nroww = size(w, 1)
+    @assert size(C, 1) == size(C, 2)
+    @assert nrow == size(w, 2)
+    @assert nroww == nbandl + nbandu + 1
+    isempty(C) && error("matrix is empty")
+    middle = nbandu + 1  # w[middle, :] contains the main diagonal of A
+    Cfact = LU(C, Int[], 0) :: CollocationLU  # factors, ipiv, info
+
+    @inbounds if nrow == 1 && iszero(w[middle, nrow])
+        throw(ZeroPivotException(1))
+    end
+
+    if nbandl == 0
+        # A is upper triangular. Check that the diagonal is nonzero.
+        @inbounds for i = 1:nrow
+            iszero(w[middle, i]) && throw(ZeroPivotException(i))
+        end
+        return Cfact
+    end
+
+    if nbandu == 0
+        # A is lower triangular. Check that the diagonal is nonzero and
+        # divide each column by its diagonal.
+        @inbounds for i = 1:(nrow - 1)
+            pivot = w[middle, i]
+            iszero(pivot) && throw(ZeroPivotException(i))
+            ipiv = inv(pivot)
+            for j = 1:min(nbandl, nrow - i)
+                w[middle + j, i] *= ipiv
+            end
+        end
+        return Cfact
+    end
+
+    # A is not just a triangular matrix.
+    # Construct the LU factorization.
+    @inbounds for i = 1:(nrow - 1)
+        pivot = w[middle, i]  # pivot for the i-th step
+        iszero(pivot) && throw(ZeroPivotException(i))
+        ipiv = inv(pivot)
+
+        # Divide each entry in column `i` below the diagonal by `pivot`.
+        for j = 1:min(nbandl, nrow - i)
+            w[middle + j, i] *= ipiv
+        end
+
+        # Subtract A[i, i+k] * (i-th column) from (i+k)-th column (below row `i`).
+        for k = 1:min(nbandu, nrow - i)
+            factor = w[middle - k, i + k]
+            for j = 1:min(nbandl, nrow - i)
+                w[middle - k + j, i + k] -= factor * w[middle + j, i]
+            end
+        end
+    end
+
+    # Check the last diagonal entry.
+    @inbounds if iszero(w[middle, nrow])
+        throw(ZeroPivotException(nrow))
+    end
+
+    Cfact
+end
+
+lu(C::CollocationMatrix, args...; kws...) = lu!(copy(C), args...; kws...)
+
+ldiv!(F::CollocationLU, y::AbstractVector) = ldiv!(y, F, y)
+
+# Solution of banded linear system A * x = y.
+# The code is adapted from Carl de Boor's BANSLV routine in FORTRAN77, via its
+# FORTRAN90 version by John Burkardt.
+# Note that `x` and `y` may be the same vector.
+function ldiv!(
+        x::AbstractVector,
+        F::CollocationLU,
+        y::AbstractVector,
+    )
+    A = parent(F.factors) :: BandedMatrix
+    w = BandedMatrices.bandeddata(A)
+    nrow = size(A, 1)
+    nbandl, nbandu = bandwidths(A)
+    middle = nbandu + 1
+    @assert size(A, 1) == size(A, 2)
+
+    if !(length(x) == length(y) == nrow)
+        throw(DimensionMismatch("vectors `x` and `y` must have length $nrow"))
+    end
+
+    if x !== y
+        copy!(x, y)
+    end
+
+    if nrow == 1
+        @inbounds x[1] /= w[middle, 1]
+        return x
+    end
+
+    # Forward pass:
+    #
+    # For i = 1:(nrow-1), subtract RHS[i] * (i-th column of L) from the
+    # right hand side, below the i-th row.
+    if nbandl != 0
+        for i = 1:(nrow - 1)
+            jmax = min(nbandl, nrow - i)
+            for j = 1:jmax
+                @inbounds x[i + j] -= x[i] * w[middle + j, i]
+            end
+        end
+    end
+
+    # Backward pass:
+    #
+    # For i = nrow:-1:1, divide RHS[i] by the i-th diagonal entry of
+    # U, then subtract RHS[i]*(i-th column of U) from right hand side, above the
+    # i-th row.
+    @inbounds for i = nrow:-1:2
+        x[i] /= w[middle, i]
+        for j = 1:min(nbandu, i - 1)
+            x[i - j] -= x[i] * w[middle - j, i]
+        end
+    end
+
+    @inbounds x[1] /= w[middle, 1]
+
+    x
+end
+
+function Base.getproperty(F::CollocationLU, d::Symbol)
+    factors = getfield(F, :factors) :: CollocationMatrix
+    A = parent(factors) :: BandedMatrix
+    data = bandeddata(A)
+    l, u = bandwidths(A)
+    middle = u + 1
+    if d === :L
+        L = similar(A, size(A)..., l, 0)
+        bandeddata(L) .= @view data[middle:(middle + l), :]
+        L[Band(0)] .= 1
+        LowerTriangular(L)
+    elseif d === :U
+        U = similar(A, size(A)..., 0, u)
+        bandeddata(U) .= @view data[1:middle, :]
+        UpperTriangular(U)
+    elseif d === :p
+        Base.OneTo(size(F, 1))    # no row permutations (no pivoting)
+    elseif d === :P
+        LinearAlgebra.I  # no row permutations
+    else
+        getfield(F, d)
+    end
+end

--- a/src/Interpolations/Interpolations.jl
+++ b/src/Interpolations/Interpolations.jl
@@ -43,15 +43,13 @@ struct Interpolation{
     # Construct Interpolation from basis and collocation points.
     function Interpolation(B, x::AbstractVector, ::Type{T}) where {T}
         # Here we construct the collocation matrix and its LU factorisation.
-        l, u = Collocation.collocation_bandwidths(order(B))
         N = length(B)
         if length(x) != N
             throw(DimensionMismatch(
                 "incompatible lengths of B-spline basis and collocation points"))
         end
-        C = BandedMatrix{T}(undef, (N, N), (l, u))
-        collocation_matrix!(C, B, x)
-        Interpolation(B, Collocation.lu_no_pivot!(C))
+        C = collocation_matrix(B, x, CollocationMatrix{T})
+        Interpolation(B, lu!(C))
     end
 end
 

--- a/src/Interpolations/Interpolations.jl
+++ b/src/Interpolations/Interpolations.jl
@@ -42,26 +42,16 @@ struct Interpolation{
 
     # Construct Interpolation from basis and collocation points.
     function Interpolation(B, x::AbstractVector, ::Type{T}) where {T}
-        # We want to construct the collocation matrix and its factorisation.
-        # TODO
-        # Ideally, we'd like to perform the LU factorisation without pivoting:
-        #
-        # - From de Boor 2001, p. 175 ("The subroutine SPLINT"): pivoting is not
-        #   needed for the collocation matrix because of its local positivity.
-        #
-        # Unfortunately, LU factorisation without pivoting is not currently
-        # supported by BandedMatrices (or by LAPACK), so we perform pivoting.
-        # Because of this, we need to allocate `l` additional bands for storing
-        # the output of the factorisation.
+        # Here we construct the collocation matrix and its LU factorisation.
         l, u = Collocation.collocation_bandwidths(order(B))
         N = length(B)
         if length(x) != N
             throw(DimensionMismatch(
                 "incompatible lengths of B-spline basis and collocation points"))
         end
-        C = BandedMatrix{T}(undef, (N, N), (l, l + u))
+        C = BandedMatrix{T}(undef, (N, N), (l, u))
         collocation_matrix!(C, B, x)
-        Interpolation(B, lu!(C))
+        Interpolation(B, Collocation.lu_no_pivot!(C))
     end
 end
 

--- a/test/collocation.jl
+++ b/test/collocation.jl
@@ -1,11 +1,11 @@
 function test_collocation(B::BSplineBasis, ::Type{T} = Float64) where {T}
     xcol = collocation_points(B)
     @inferred collocation_matrix(B, xcol, Matrix{T})
-    @inferred collocation_matrix(B, xcol, BandedMatrix{T})
+    @inferred collocation_matrix(B, xcol, CollocationMatrix{T})
     @inferred collocation_matrix(B, xcol, SparseMatrixCSC{T})
 
     C_dense = collocation_matrix(B, xcol, Matrix{T})
-    C_banded = collocation_matrix(B, xcol, BandedMatrix{T})
+    C_banded = collocation_matrix(B, xcol, CollocationMatrix{T})
     C_sparse = collocation_matrix(B, xcol, SparseMatrixCSC{T})
 
     @test C_dense == C_banded

--- a/test/collocation.jl
+++ b/test/collocation.jl
@@ -12,6 +12,9 @@ function test_collocation_matrix()
         F = lu(C)
         @test F.L == [1]'
         @test F.U == [3]'
+        y = [6]
+        x = F \ y
+        @test x == [2]
     end
 
     @testset "Non-square" begin
@@ -40,6 +43,8 @@ function test_collocation_matrix()
         L[4, 4] = 0
         @test_throws ZeroPivotException(4) lu!(L)
     end
+
+    nothing
 end
 
 function test_collocation(B::BSplineBasis, ::Type{T} = Float64) where {T}

--- a/test/splines.jl
+++ b/test/splines.jl
@@ -106,6 +106,15 @@ function test_splines(B::BSplineBasis, knots_in)
 
     C = @inferred collocation_matrix(B, xcol)
 
+    let N = size(C, 1)
+        T = eltype(C)
+        l, u = bandwidths(C)
+        @test startswith(
+            sprint(show, MIME("text/plain"), C),
+            "$N×$N CollocationMatrix{$T} with bandwidths ($l, $u):\n",
+        )
+    end
+
     @testset "LU factorisation" begin
         T = eltype(C)
         @test T === Float64
@@ -119,6 +128,10 @@ function test_splines(B::BSplineBasis, knots_in)
         y = sin.(xcol)
         u = F \ y
         @test C * u ≈ y
+
+        let v = similar(u, length(u) - 2)
+            @test_throws DimensionMismatch ldiv!(v, F, y)
+        end
     end
 
     @testset "Spline (k = $k)" begin

--- a/test/splines.jl
+++ b/test/splines.jl
@@ -14,10 +14,10 @@ function test_polynomial(x, ::BSplineOrder{k}) where {k}
     Pint = (0, ntuple(d -> P[d] / d, Val(k))...)  # antiderivative
 
     # Interpolate polynomial at `x` locations.
-    itp = let y = eval_poly(x, P)
-        @inferred interpolate(x, y, BSplineOrder(k))
-        interpolate(x, y, k)
-    end
+    y = eval_poly(x, P)
+    @inferred interpolate(x, y, BSplineOrder(k))
+    itp = interpolate(x, y, k)
+    @test itp.(x) ≈ y
 
     S = spline(itp)
     @test length(S) == length(x)


### PR DESCRIPTION
This PR adds a port of the LU factorisation by de Boor, which avoids pivoting thanks to the total positivity property of banded collocation matrices used for spline calculations.

This allows to reduce memory usage of the factorisation, since there is no need to allocate extra bands as in the pivoted implementation of BandedMatrices / LAPACK. The factorisation itself seems to be much faster as well.

The implementation is directly based off the [Fortran 90 version](https://people.sc.fsu.edu/~jburkardt/f_src/pppack/pppack.f90) of de Boor's FORTRAN77 code, made by John Burkardt.

Things to do:

- [x] Implement `CollocationMatrix` as a `BandedMatrix` wrapper.
- [x] Then, rename `lu_no_pivot!` to just `LinearAlgebra.lu!`, making sure that `pivot = Val(false)`.
- [x] Define `lu` (without the `!`).
- [x] `collocation_matrix` should return a `CollocationMatrix`, maybe with an optional parameter allowing non-square matrices (which should be regular sparse matrices?).
- [x] Add tests for special cases.
- [ ] Maybe this implementation would make sense in BandedMatrices, where the `pivot = Val(false)` option is not currently implemented?