### PR TITLE
Add convenience functions for interpolations

### DIFF
--- a/src/BSplines/basis.jl
+++ b/src/BSplines/basis.jl
@@ -75,6 +75,7 @@ end
     BSplineBasis(BSplineOrder(k), args...; kwargs...)
 
 Base.:(==)(A::BSplineBasis, B::BSplineBasis) =
+    A === B ||
     order(A) == order(B) && knots(A) == knots(B)
 
 """

--- a/src/BSplines/basis.jl
+++ b/src/BSplines/basis.jl
@@ -74,6 +74,9 @@ end
 @inline BSplineBasis(k::Integer, args...; kwargs...) =
     BSplineBasis(BSplineOrder(k), args...; kwargs...)
 
+Base.:(==)(A::BSplineBasis, B::BSplineBasis) =
+    order(A) == order(B) && knots(A) == knots(B)
+
 """
     getindex(B::AbstractBSplineBasis, i, [T = Float64])
 

--- a/src/Recombinations/bases.jl
+++ b/src/Recombinations/bases.jl
@@ -173,6 +173,10 @@ struct RecombinedBSplineBasis{
         RecombinedBSplineBasis((op, ), args...)
 end
 
+Base.:(==)(A::RecombinedBSplineBasis, B::RecombinedBSplineBasis) =
+    constraints(A) == constraints(B) &&
+    parent(A) == parent(B)
+
 function Base.summary(io::IO, R::RecombinedBSplineBasis)
     summary_basis(io, R)
     cl, cr = constraints(R)

--- a/src/Recombinations/bases.jl
+++ b/src/Recombinations/bases.jl
@@ -174,6 +174,7 @@ struct RecombinedBSplineBasis{
 end
 
 Base.:(==)(A::RecombinedBSplineBasis, B::RecombinedBSplineBasis) =
+    A === B ||
     constraints(A) == constraints(B) &&
     parent(A) == parent(B)
 

--- a/src/SplineInterpolations/SplineInterpolations.jl
+++ b/src/SplineInterpolations/SplineInterpolations.jl
@@ -7,6 +7,12 @@ using ..Splines
 using BandedMatrices
 using LinearAlgebra
 
+import ..BSplines:
+    order, knots, basis
+
+import ..Splines:
+    coefficients, integral
+
 import Interpolations:
     interpolate, interpolate!
 
@@ -63,7 +69,14 @@ Returns the [`Spline`](@ref) associated to the interpolation.
 """
 spline(I::Interpolation) = I.s
 
+# For convenience, wrap some commonly used functions that apply to the
+# underlying spline.
 (I::Interpolation)(x) = spline(I)(x)
+Base.diff(I::Interpolation, etc...) = diff(spline(I), etc...)
+
+for f in (:basis, :order, :knots, :coefficients, :integral)
+    @eval $f(I::Interpolation) = $f(spline(I))
+end
 
 """
     interpolate!(I::Interpolation, y::AbstractVector)

--- a/src/Splines/spline.jl
+++ b/src/Splines/spline.jl
@@ -53,10 +53,10 @@ function Base.show(io::IO, S::Spline)
 end
 
 Base.:(==)(P::Spline, Q::Spline) =
-    basis(P) === basis(Q) && coefficients(P) == coefficients(Q)
+    basis(P) == basis(Q) && coefficients(P) == coefficients(Q)
 
 Base.isapprox(P::Spline, Q::Spline; kwargs...) =
-    basis(P) === basis(Q) &&
+    basis(P) == basis(Q) &&
     isapprox(coefficients(P), coefficients(Q); kwargs...)
 
 function Spline(::UndefInitializer, B::BSplineBasis,

--- a/test/recombination.jl
+++ b/test/recombination.jl
@@ -191,6 +191,12 @@ function test_basis_recombination()
         R = RecombinedBSplineBasis(Derivative(1), B)
         coefs = rand(length(R))
 
+        @testset "Equality" begin
+            @test R != B
+            @test R != RecombinedBSplineBasis(Derivative(0), B)
+            @test R == RecombinedBSplineBasis(Derivative(1), B)
+        end
+
         # This constructs a Spline in the parent B-spline basis.
         S = @inferred Spline(R, coefs)
         @test S isa Spline

--- a/test/splines.jl
+++ b/test/splines.jl
@@ -17,21 +17,33 @@ function test_polynomial(x, ::BSplineOrder{k}) where {k}
     # Interpolate polynomial at `x` locations.
     y = eval_poly(x, P)
     itp = @inferred interpolate(x, y, BSplineOrder(k))
-    @test itp.(x) ≈ y
 
     S = spline(itp)
     @test length(S) == length(x)
 
-    let x = (x[2] + x[3]) / 3
-        @test itp(x) == S(x)  # these are equivalent
+    @testset "Interpolations" begin
+        @test itp.(x) ≈ y
+
+        let x = (x[2] + x[3]) / 3
+            @test itp(x) == S(x)  # these are equivalent
+        end
+
+        @test order(itp) === order(S)
+        @test basis(itp) === basis(S)
+        @test knots(itp) === knots(S)
+        @test coefficients(itp) === coefficients(S)
+        @test integral(itp) == integral(S)
+        @test diff(itp, Derivative(1)) == diff(S, Derivative(1))
+
+        # "incompatible lengths of B-spline basis and collocation points"
+        @test_throws(
+            DimensionMismatch,
+            SplineInterpolations.Interpolation(basis(S), x[1:4], eltype(S)),
+        )
+
+        # "input data has incorrect length"
+        @test_throws DimensionMismatch interpolate!(itp, rand(length(x) - 1))
     end
-
-    # "incompatible lengths of B-spline basis and collocation points"
-    @test_throws(DimensionMismatch,
-                 SplineInterpolations.Interpolation(basis(S), x[1:4], eltype(S)))
-
-    # "input data has incorrect length"
-    @test_throws DimensionMismatch interpolate!(itp, rand(length(x) - 1))
 
     S′ = diff(S, Derivative(1))
     Sint = integral(S)

--- a/test/splines.jl
+++ b/test/splines.jl
@@ -199,6 +199,18 @@ function test_splines(::BSplineOrder{k}) where {k}
         @inferred BSplineBasis(BSplineOrder(k), copy(x), augment=Val(true))
         @inferred (() -> BSplineBasis(k, copy(x)))()
         g = BSplineBasis(k, copy(x))
+
+        @testset "BSplineBasis equality" begin
+            h = BSplineBasis(k, copy(x))
+            @test g == h
+
+            h = BSplineBasis(BSplineOrder(k + 1), copy(x))
+            @test g != h
+
+            h = BSplineBasis(k, x .+ 1)
+            @test g != h
+        end
+
         @test order(g) == k
         test_splines(g, x)
     end


### PR DESCRIPTION
Now, functions like `diff`, `integral`, ... are defined for `Interpolation` objects, which means that one does not need to extract the underlying `Spline`, making things more user friendly.

This PR also relaxes the definition of equality between splines: the underlying basis doesn't need to be exactly the same object -- it may be a different but equivalent basis (same knots and order).