### PR TITLE
Implement different spline approximation methods

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,6 +39,7 @@ end
             "bsplines.md",
             "splines.md",
             "interpolation.md",
+            "approximation.md",
             "recombination.md",
             "tensors.md",
             "galerkin.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,7 @@ with_checks = !MAKE_FAST
 example_dir = joinpath(@__DIR__, "..", "examples")
 output_dir = joinpath(@__DIR__, "src/generated")
 
-for example in ("heat.jl", )
+for example in ["approximation.jl", "heat.jl", ]
     filename = joinpath(example_dir, example)
     Literate.markdown(filename, output_dir, documenter=true)
 end
@@ -33,6 +33,7 @@ end
     pages=[
         "Home" => "index.md",
         "Examples" => [
+            "generated/approximation.md",
             "generated/heat.md",
         ],
         "Library" => [

--- a/docs/src/approximation.md
+++ b/docs/src/approximation.md
@@ -1,0 +1,27 @@
+# Function approximation
+
+```@meta
+CurrentModule = BSplineKit.SplineApproximations
+```
+
+Function approximation using splines.
+
+```@docs
+SplineApproximations
+```
+
+## Functions
+
+```@docs
+approximate
+approximate!
+```
+
+## Approximation methods
+
+```@docs
+SplineApproximations.AbstractApproxMethod
+VariationDiminishing
+ApproxByInterpolation
+MinimiseL2Error
+```

--- a/docs/src/collocation.md
+++ b/docs/src/collocation.md
@@ -1,4 +1,4 @@
-# Collocation arrays
+# Collocation tools
 
 ```@meta
 CurrentModule = BSplineKit.Collocation

--- a/docs/src/galerkin.md
+++ b/docs/src/galerkin.md
@@ -1,7 +1,14 @@
-# Galerkin arrays
+# Galerkin tools
 
 ```@meta
 CurrentModule = BSplineKit
+```
+
+## Projections
+
+```@docs
+galerkin_projection
+galerkin_projection!
 ```
 
 ## Matrices

--- a/docs/src/interpolation.md
+++ b/docs/src/interpolation.md
@@ -1,19 +1,16 @@
-# Interpolation
+# Data interpolation
 
 ```@meta
 CurrentModule = BSplineKit.SplineInterpolations
 ```
 
-High-level interpolation of gridded data and function approximation using B-splines.
+High-level interpolation of gridded data using B-splines.
 
 ## Functions
 
 ```@docs
 interpolate
 interpolate!
-approximate
-approximate!
-spline
 ```
 
 ## Types

--- a/docs/src/splines.md
+++ b/docs/src/splines.md
@@ -20,3 +20,10 @@ basis(::Spline)
 diff
 integral
 ```
+
+## Spline wrappers
+
+```@docs
+SplineWrapper
+spline
+```

--- a/examples/approximation.jl
+++ b/examples/approximation.jl
@@ -1,0 +1,225 @@
+# # Function approximation
+#
+# The objective of this example is to approximate a known function ``f`` by a
+# spline.
+#
+# ## Exact function
+#
+# We consider the function ``f(x) = e^{-x} \cos(8πx)`` in the interval
+# ``x ∈ [0, 1]``.
+
+using CairoMakie
+CairoMakie.activate!(type = "svg")
+
+x_interval = 0..1
+f(x) = exp(-x) * cospi(8x)
+
+fig = Figure(resolution = (800, 600))
+ax = Axis(fig[1, 1]; xlabel = "x")
+lines!(ax, x_interval, f)
+fig
+
+# ## Approximation space
+
+# To approximate this function using a spline, we first need to define a
+# B-spline basis ``\{ b_i \}_{i = 1}^N`` describing a spline space.
+# The approximating spline can then be written as
+#
+# ```math
+# g(x) = ∑_{i = 1}^N c_i b_i(x),
+# ```
+#
+# where the ``c_i`` are the B-spline coefficients describing the spline.
+# The objective is thus to find the coefficients ``c_i`` that result in the best
+# possible approximation of the function ``f``.
+#
+# Here we use splines of order ``k = 4`` (polynomial degree ``d = 3``, i.e.
+# cubic splines).
+# For simplicity, we choose the B-spline knots to be uniformly distributed.
+
+using BSplineKit
+
+ξs = range(x_interval; length = 15)
+B = BSplineBasis(BSplineOrder(4), ξs)
+
+# We plot below the knots and the basis functions describing the spline space.
+# Note that knots are represented by grey crosses.
+
+function plot_knots!(ax, ts; ybase = 0, knot_offset = 0.03, kws...)
+    ys = zero(ts) .+ ybase
+    ## Add offset to distinguish knots with multiplicity > 1
+    if knot_offset !== nothing
+        for i in eachindex(ts)[(begin + 1):end]
+            if ts[i] == ts[i - 1]
+                ys[i] = ys[i - 1] + knot_offset
+            end
+        end
+    end
+    scatter!(ax, ts, ys; marker = :x, color = :gray, markersize = 16, kws...)
+    ax
+end
+
+function plot_basis!(ax, B; eval_args = (), kws...)
+    cmap = cgrad(:tab20)
+    N = length(B)
+    ts = knots(B)
+    hlines!(ax, 0; color = :gray)
+    for (n, bi) in enumerate(B)
+        color = cmap[(n - 1) / (N - 1)]
+        i, j = extrema(support(bi))
+        lines!(ax, ts[i]..ts[j], x -> bi(x, eval_args...); color, linewidth = 2.5)
+    end
+    plot_knots!(ax, ts; kws...)
+    ax
+end
+
+fig = Figure(resolution = (800, 600))
+ax = Axis(fig[1, 1]; xlabel = "x", ylabel = "bᵢ(x)")
+plot_basis!(ax, B; knot_offset = 0.05)
+fig
+
+# ## Approximating the function
+#
+# Three different methods are implemented in BSplineKit to approximate
+# functions.
+# In increasing order of accuracy and complexity, these are:
+#
+# ### 1. [`VariationDiminishing`](@ref)
+#
+# Implements Schoenberg's variation diminishing approximation.
+# This simply consists on estimating the spline coefficients as ``c_i =
+# f(x_i)``, where the ``x_i`` are the Greville sites.
+# These are obtained by window-averaging the B-spline knots ``t_j``:
+#
+# ```math
+# x_i = \frac{1}{k - 1} ∑_{j = 1}^{k - 1} t_{i + j}.
+# ```
+#
+# This approximation is expected to preserve the shape of the function.
+# However, as shown below, it is usually very inaccurate as an actual
+# approximation, and should only be used when a qualitative estimation of ``f``
+# is sufficient.
+
+S_vd = approximate(f, B, VariationDiminishing())
+
+# ### 2. [`ApproxByInterpolation`](@ref)
+#
+# Approximates the original function by interpolating on a discrete set of
+# interpolation points.
+# In other words, the resulting spline exactly matches ``f`` at those points.
+#
+# By default, the interpolation points are chosen as the Greville sites
+# associated to the B-spline basis (using [`collocation_points`](@ref); see also
+# [`Collocation.AvgKnots`](@ref)).
+# For more control, the interpolation points may also be directly set via the
+# [`ApproxByInterpolation`](@ref) constructor.
+#
+# In the below example, we pass the B-spline basis to the
+# `ApproxByInterpolation` constructor, which automatically determines the
+# collocation points as explained above.
+
+S_interp = approximate(f, B, ApproxByInterpolation(B))  # or simply approximate(f, B)
+
+# ### 3. [`MinimiseL2Error`](@ref)
+#
+# Approximates the function by minimising the ``L^2`` distance between ``f`` and
+# its spline approximation ``g``.
+#
+# In other words, it minimises
+# ```math
+# \mathcal{L}[g] = {\left\lVert f - g \right\rVert}^2 = \left< f - g, f - g \right>,
+# ```
+# where
+# ```math
+# \left< u, v \right> = ∫_a^b u(x) \, v(x) \, \mathrm{d}x
+# ```
+# is the inner product between two functions, and ``a`` and ``b`` are the
+# boundaries of the prescribed B-spline basis.
+#
+# One can show that the optimal coefficients ``c_i`` minimising the ``L^2`` error
+# are the solution to the linear system ``\bm{M} \bm{c} = \bm{φ}``,
+# where ``M_{ij} = \left< b_i, b_j \right>`` and ``φ_i = \left< b_i, f \right>``.
+# These two terms are respectively computed by [`galerkin_matrix`](@ref) and
+# [`galerkin_projection`](@ref).
+#
+# Indeed, this can be shown by taking the differential
+# ```math
+# δ\mathcal{L}[g] = \mathcal{L}[g + δg] - \mathcal{L}[g]
+# = 2 \left< δg, g - f \right>,
+# ```
+# where ``δg`` is a small perturbation of the spline ``g``.
+# The optimal spline ``g^*``, minimising the ``L^2`` distance, is such that
+# ``δ\mathcal{L}[g^*] = 0``.
+#
+# Noting that ``g = c_i b_i`` (where summing is implicitly performed over
+# repeated indices), the perturbation is given by ``δg = δc_i b_i``, as the
+# B-spline basis is assumed fixed.
+# The optimal spline then satisfies
+# ```math
+# \left< b_i, g^* - f \right> δc_i
+# = \left[ \left< b_i, b_j \right> c_j^* - \left< b_i, f \right> \right] δc_i
+# = \left[ M_{ij} c_j^* - φ_i \right] δc_i
+# = 0
+# ```
+# for all perturbations ``δ\bm{c}``, leading to the linear system stated above.
+#
+# As detailed in [`galerkin_projection`](@ref), integrals are computed via
+# Gauss--Legendre quadratures, in a way that ensures that the result is exact
+# when ``f`` is a polynomial of degree up to ``k - 1`` (or more generally, a
+# spline belonging to the space spanned by the chosen B-spline basis).
+
+S_minL2 = approximate(f, B, MinimiseL2Error())
+
+# ## Method comparison
+#
+# Below, the approximations using the three methods are compared to the actual
+# function ``f``.
+
+fig = Figure(resolution = (1000, 750))
+colours = theme(fig.scene).palette.color[]
+style_vd = (color = colours[3], label = "Variation diminishing")
+style_interp = (color = colours[2], label = "Interpolation")
+style_minL2 = (color = colours[1], label = "L² minimisation")
+let ax = Axis(fig[1:2, 1]; xlabel = "x", ylabel = "Approximation")
+    plot_knots!(ax, knots(B); knot_offset = nothing)
+    lines!(ax, x_interval, f; color = :black, linewidth = 2, label = "Original")
+    lines!(ax, x_interval, x -> S_vd(x); style_vd...)
+    lines!(ax, x_interval, x -> S_interp(x); style_interp...)
+    lines!(ax, x_interval, x -> S_minL2(x); style_minL2...)
+    axislegend(ax)
+end
+let ax = Axis(fig[1, 2]; ylabel = "Difference with original")
+    plot_knots!(ax, knots(B); knot_offset = nothing)
+    lines!(ax, x_interval, x -> S_interp(x) - f(x); style_interp...)
+    lines!(ax, x_interval, x -> S_minL2(x) - f(x); style_minL2...)
+    hidexdecorations!(ax; grid = false)
+    axislegend(ax; position = :rt, orientation = :horizontal)
+end
+let ax = Axis(fig[2, 2]; xlabel = "x", ylabel = "Squared difference", yscale = log10)
+    ylims!(1e-8, 1e-2)
+    plot_knots!(ax, knots(B); knot_offset = nothing, ybase = 1e-6)
+    lines!(ax, x_interval, x -> abs2(S_interp(x) - f(x)); style_interp...)
+    lines!(ax, x_interval, x -> abs2(S_minL2(x) - f(x)); style_minL2...)
+end
+fig
+
+# As seen above, the **variation diminishing approximation**, while capturing the
+# shape of the original function, doesn't really provide an accurate
+# approximation of it.
+#
+# The other two methods are much more accurate.
+# On the right half of the figure, a detailed comparison of the two is provided,
+# by plotting the difference between each approximation and the actual ``f``
+# function.
+#
+# The **interpolation method** works pretty well, matching exactly the actual
+# function at the interpolation points.
+# Note that, in this example, most interpolation points match the spline knots.
+# This is because we're using splines of even degree (``k = 4``) and because
+# knots are uniformly spaced.
+#
+# Nevertheless, when looking at the global error, the **``L^2`` minimisation
+# method** works best, as expected.
+# In particular, as seen above, it reduces the maximum approximation error (i.e.
+# the ``L^∞`` distance, ``{\left\lVert f - g \right\rVert}_∞ = \max |f(x) -
+# g(x)|``) compared to the interpolation approach.

--- a/examples/heat.jl
+++ b/examples/heat.jl
@@ -182,14 +182,10 @@ T = recombination_matrix(R)
 
 # First, we approximate this initial condition in the recombined
 # B-spline basis that we have just constructed.
-# This may be easily done using [`approximate`](@ref), which interpolates the
-# function by evaluating it over a discrete set of interpolation points.
+# This may be easily done using [`approximate`](@ref):
 
 θ₀(x) = 1 + cos(π * x)
-θ₀_spline = approximate(θ₀, R)
-
-# Note that the interpolation points don't include the boundaries, since there
-# the boundary conditions are exactly satisfied by the spline approximation.
+θ₀_spline = approximate(θ₀, R, MinimiseL2Error())
 
 # To see that everything went well, we can plot the exact initial condition and
 # its spline approximation, which show no important differences.

--- a/src/BSplineKit.jl
+++ b/src/BSplineKit.jl
@@ -28,4 +28,7 @@ include("Galerkin/Galerkin.jl")
 include("SplineInterpolations/SplineInterpolations.jl")
 @reexport using .SplineInterpolations
 
+include("SplineApproximations/SplineApproximations.jl")
+@reexport using .SplineApproximations
+
 end

--- a/src/Collocation/Collocation.jl
+++ b/src/Collocation/Collocation.jl
@@ -36,8 +36,7 @@ x_i = \\frac{1}{k - 1} ∑_{j = 1}^{k - 1} t_{i + j}
 ```
 
 The resulting collocation points are sometimes called Greville sites
-(de Boor 2001) or Marsden--Schoenberg points (e.g. Botella & Shariff IJCFD
-2003).
+(de Boor 2001).
 """
 struct AvgKnots <: SelectionMethod end
 

--- a/src/Collocation/Collocation.jl
+++ b/src/Collocation/Collocation.jl
@@ -29,7 +29,11 @@ abstract type SelectionMethod end
 """
     AvgKnots <: SelectionMethod
 
-Each collocation point is chosen as a sliding average over `k - 1` knots.
+Each collocation point is chosen as a sliding average over `k - 1` knots:
+
+```math
+x_i = \\frac{1}{k - 1} ∑_{j = 1}^{k - 1} t_{i + j}
+```
 
 The resulting collocation points are sometimes called Greville sites
 (de Boor 2001) or Marsden--Schoenberg points (e.g. Botella & Shariff IJCFD

--- a/src/Collocation/matrix.jl
+++ b/src/Collocation/matrix.jl
@@ -32,9 +32,6 @@ positivity of spline collocation matrices (de Boor 2001, p. 175).
 well as out-of-place factorisation using [`lu`](@ref). LU decomposition may also
 be performed via `factorize`.
 
-!!! warning "Matrix shape"
-    For now, LU factorisation is only supported for **square** collocation matrices.
-
 """
 struct CollocationMatrix{
         T,

--- a/src/Galerkin/Galerkin.jl
+++ b/src/Galerkin/Galerkin.jl
@@ -1,6 +1,8 @@
 module Galerkin
 
 export
+    galerkin_projection,
+    galerkin_projection!,
     galerkin_matrix,
     galerkin_matrix!,
     galerkin_tensor,
@@ -21,7 +23,8 @@ using StaticArrays
 const DerivativeCombination{N} = Tuple{Vararg{Derivative,N}}
 
 include("quadratures.jl")
-include("linear.jl")     # galerkin_matrix
-include("quadratic.jl")  # galerkin_tensor
+include("projection.jl")  # galerkin_projection
+include("linear.jl")      # galerkin_matrix
+include("quadratic.jl")   # galerkin_tensor
 
 end

--- a/src/Galerkin/linear.jl
+++ b/src/Galerkin/linear.jl
@@ -174,7 +174,7 @@ function galerkin_matrix!(
     same_ij = B1 == B2 && deriv[1] == deriv[2]
 
     if size(S) != length.(Bs)
-        throw(ArgumentError("wrong dimensions of Galerkin matrix"))
+        throw(DimensionMismatch("wrong dimensions of Galerkin matrix"))
     end
 
     # Orders and knots are assumed to be the same (see _check_bases).

--- a/src/Galerkin/projection.jl
+++ b/src/Galerkin/projection.jl
@@ -51,9 +51,7 @@ function galerkin_projection!(
     )
     N = length(B)
     if length(φ) != N
-        throw(DimensionMismatch(
-            "output vector must have length $N (got length $(length(φ)))"
-        ))
+        throw(DimensionMismatch("incorrect length of output vector φ"))
     end
     Base.require_one_based_indexing(φ)
 
@@ -90,10 +88,17 @@ function galerkin_projection!(
 
         # Evaluate all required basis functions on quadrature nodes.
         bis = eval_basis_functions(B, is, xs, deriv)
-        fs = map(f, xs)
+
+        fs = ntuple(i -> f(xs[i]), Val(length(xs)))  # this works fine!
+
+        # For some reason, the alternatives below allocate and give bad
+        # performance... (on Julia 1.7-beta2)
+        # fs = map(f, xs)
+        # fs = f.(xs)
 
         for (ni, i) in enumerate(is)
-            φ[i] += metric.α * ((bis[ni] .* fs) ⋅ quadw)
+            bs = bis[ni]
+            φ[i] += metric.α * ((bs .* fs) ⋅ quadw)
         end
     end
 

--- a/src/Galerkin/projection.jl
+++ b/src/Galerkin/projection.jl
@@ -1,0 +1,101 @@
+@doc raw"""
+    galerkin_projection(
+        f, B::AbstractBSplineBasis,
+        [deriv = Derivative(0)], [VectorType = Vector{Float64}],
+    )
+
+Perform Galerkin projection of a function `f` onto the given basis.
+
+By default, returns a vector with values
+
+```math
+φ_i = ⟨ b_i, f ⟩
+= ∫_a^b b_i(x) \, f(x) \, \mathrm{d}x,
+```
+
+where ``a`` and ``b`` are the boundaries of the B-spline basis
+``\{ b_i \}_{i = 1}^N``.
+
+The integrations are performed using Gauss--Legendre quadrature.
+The number of quadrature nodes is chosen so that the result is exact when ``f``
+is a polynomial of degree ``k - 1`` (or, more generally, a spline belonging to
+the space spanned by the basis `B`).
+Here ``k`` is the order of the B-spline basis.
+In the more general case, this function returns a quadrature approximation of
+the projection.
+
+See also [`galerkin_projection!`](@ref) for the in-place operation, and
+[`galerkin_matrix`](@ref) for more details.
+"""
+function galerkin_projection(
+        f, B::AbstractBSplineBasis,
+        deriv = Derivative(0),
+        ::Type{V} = Vector{Float64},
+    ) where {V <: AbstractVector}
+    N = length(B)
+    φ = V(undef, N)
+    galerkin_projection!(f, φ, B, deriv)
+end
+
+"""
+    galerkin_projection!(
+        f, φ::AbstractVector, B::AbstractBSplineBasis, [deriv = Derivative(0)],
+    )
+
+Compute Galerkin projection ``φ_i = ⟨ b_i, f ⟩``.
+
+See [`galerkin_projection`](@ref) for details.
+"""
+function galerkin_projection!(
+        f, φ::AbstractVector, B::AbstractBSplineBasis, deriv = Derivative(0),
+    )
+    N = length(B)
+    if length(φ) != N
+        throw(DimensionMismatch(
+            "output vector must have length $N (got length $(length(φ)))"
+        ))
+    end
+    Base.require_one_based_indexing(φ)
+
+    k = order(B)
+    ts = knots(B)
+
+    # Quadrature information (nodes, weights).
+    quadx, quadw = _quadrature_prod(Val(2k - 2))
+    @assert length(quadx) == k  # we need k quadrature points per knot segment
+
+    fill!(φ, 0)
+
+    nlast = last(eachindex(ts))
+
+    # We loop over all knot segments Ω[n] = (ts[n], ts[n + 1]).
+    # For all B-splines with support in this segment, we integrate the product
+    # B[i] * f over this segment, adding the result to φ[i].
+    @inbounds for n in eachindex(ts)
+        n == nlast && break
+        tn, tn1 = ts[n], ts[n + 1]
+        tn1 == tn && continue  # interval of length = 0
+
+        metric = QuadratureMetric(tn, tn1)
+
+        # Unnormalise quadrature nodes, such that xs ∈ [tn, tn1]
+        xs = metric .* quadx
+        # @assert all(x -> tn ≤ x ≤ tn1, xs)
+
+        is = nonzero_in_segment(B, n)
+
+        # This is a property of B-spline bases, which should be preserved by
+        # derived (recombined) bases.
+        @assert 0 < length(is) ≤ k
+
+        # Evaluate all required basis functions on quadrature nodes.
+        bis = eval_basis_functions(B, is, xs, deriv)
+        fs = map(f, xs)
+
+        for (ni, i) in enumerate(is)
+            φ[i] += metric.α * ((bis[ni] .* fs) ⋅ quadw)
+        end
+    end
+
+    φ
+end

--- a/src/Galerkin/quadratic.jl
+++ b/src/Galerkin/quadratic.jl
@@ -25,7 +25,7 @@ function galerkin_tensor(
     dims = length.(Bs)
     b = order(first(Bs)) - 1   # band width
     if length(Bs[1]) != length(Bs[2])
-        throw(ArgumentError("the first two bases must have the same lengths"))
+        throw(DimensionMismatch("the first two bases must have the same lengths"))
     end
     δl, δr = num_constraints(Bs[3]) .- num_constraints(Bs[1])
     A = BandedTensor3D{T}(undef, dims, Val(b), bandshift=(0, 0, δl))
@@ -56,7 +56,7 @@ function galerkin_tensor!(
 
     Ns = size(A)
     if Ns != length.(Bs)
-        throw(ArgumentError("wrong dimensions of Galerkin tensor"))
+        throw(DimensionMismatch("wrong dimensions of Galerkin tensor"))
     end
 
     Bi, Bj, Bl = Bs

--- a/src/Galerkin/quadratures.jl
+++ b/src/Galerkin/quadratures.jl
@@ -19,6 +19,48 @@
 # Here, p is the polynomial order (p = 2k - 2 for the product of two B-splines).
 function _quadrature_prod(::Val{p}) where {p}
     n = cld(p + 1, 2)
+    _gausslegendre(Val(n))
+end
+
+# Precomputed Gauss--Legendre nodes and weights, for low numbers of nodes.
+# Copied from FastGaussQuadrature.jl, with the difference that the
+# implementation below directly returns SVector's (avoiding small allocations).
+_gausslegendre(::Val{1}) = (
+    SVector(0.0),
+    SVector(2.0),
+)
+
+_gausslegendre(::Val{2}) = (
+    SVector(-1 / sqrt(3), 1 / sqrt(3)),
+    SVector(1.0, 1.0),
+)
+
+_gausslegendre(::Val{3}) = (
+    SVector(-sqrt(3 / 5), 0.0, sqrt(3 / 5)),
+    SVector(5 / 9, 8 / 9, 5 / 9),
+)
+
+function _gausslegendre(::Val{4})
+    a = 2 / 7 * sqrt(6 / 5)
+    (
+        SVector(-sqrt(3 / 7 + a), -sqrt(3/7-a), sqrt(3/7-a), sqrt(3/7+a)),
+        SVector((18 - sqrt(30)) / 36, (18 + sqrt(30)) / 36,
+                (18 + sqrt(30)) / 36, (18 - sqrt(30)) / 36),
+    )
+end
+
+function _gausslegendre(::Val{5})
+    b = 2 * sqrt(10 / 7)
+    (
+        SVector(-sqrt(5 + b) / 3, -sqrt(5 - b) / 3, 0.0,
+                 sqrt(5 - b) / 3,  sqrt(5 + b) / 3),
+        SVector((322 - 13 * sqrt(70)) / 900, (322 + 13 * sqrt(70)) / 900, 128 / 225,
+                (322 + 13 * sqrt(70)) / 900, (322 - 13 * sqrt(70)) / 900),
+    )
+end
+
+# Fallback: call `gausslegendre` from FastGaussQuadrature.jl
+function _gausslegendre(::Val{n}) where {n}
     x, w = gausslegendre(n)
     SVector{n}(x), SVector{n}(w)
 end

--- a/src/Recombinations/bases.jl
+++ b/src/Recombinations/bases.jl
@@ -28,7 +28,7 @@ basis is enough to apply homogeneous Dirichlet BCs. Imposing BCs for derivatives
 is slightly more complex, but still possible.
 
 Note that, when combining basis recombination with [collocation methods](@ref
-Collocation-arrays), there must be **no** collocation points at the boundaries,
+Collocation-tools), there must be **no** collocation points at the boundaries,
 or the resulting collocation matrices may not be invertible.
 
 ## Order of the boundary condition

--- a/src/SplineApproximations/SplineApproximations.jl
+++ b/src/SplineApproximations/SplineApproximations.jl
@@ -1,0 +1,284 @@
+"""
+    SplineApproximations
+
+Module for function approximation using splines.
+
+The general idea is to find the spline ``g(x)`` in a given spline space that
+best approximates a known function ``f(x)``.
+In other words, given a predefined [`BSplineBasis`](@ref), the objective is to
+find some appropriate B-spline coefficients such that the resulting spline
+appropriately approximates ``f``.
+Different approximation approaches are proposed, trading accuracy and speed.
+"""
+module SplineApproximations
+
+using ..BSplines
+using ..Collocation: collocation_points
+using ..SplineInterpolations
+using ..Splines
+
+# For documentation
+using ..Galerkin: galerkin_matrix
+using ..Recombinations: RecombinedBSplineBasis
+
+export
+    VariationDiminishing,
+    ApproxByInterpolation,
+    MinimiseL2Error,
+    MinimizeL2Error,
+    approximate,
+    approximate!
+
+"""
+    AbstractApproxMethod
+
+Abstract type describing a type of approximation method.
+"""
+abstract type AbstractApproxMethod end
+
+Base.show(io::IO, m::AbstractApproxMethod) = print(io, nameof(typeof(m)))
+
+"""
+    VariationDiminishing <: AbstractApproxMethod
+
+Schoenberg's variation diminishing spline approximation.
+
+Approximates a function ``f`` by setting the B-spline coefficients as
+``c_i = f(x_i)``, where the locations ``x_i`` are chosen as the Greville sites:
+
+```math
+x_i = \\frac{1}{k - 1} ∑_{j = 1}^{k - 1} t_{i + j}
+```
+
+This method is expected to provide a decent low-accuracy approximation of the
+function ``f`` .
+For details, see e.g. de Boor 2001, chapter XI.
+
+!!! warning
+
+    Currently, this method is not guaranteed to work well with recombined
+    B-spline bases (of type [`RecombinedBSplineBasis`](@ref)).
+
+"""
+struct VariationDiminishing <: AbstractApproxMethod end
+
+Base.show(io::IO, ::VariationDiminishing) = print(io, "variation diminishing")
+
+"""
+    ApproxByInterpolation <: AbstractApproxMethod
+
+Approximate function by a spline that passes through the given set of points.
+
+The number of points must be equal to the length of the B-spline basis defining
+the approximation space.
+
+See belows for different ways of specifying the interpolation points.
+
+---
+
+    ApproxByInterpolation(xs::AbstractVector)
+
+Specifies an approximation by interpolation at the given points `xs`.
+
+---
+
+    ApproxByInterpolation(B::AbstractBSplineBasis)
+
+Specifies an approximation by interpolation at an automatically-determined set
+of points, which are expected to be appropriate for the given basis.
+
+The interpolation points are determined by calling [`collocation_points`](@ref).
+"""
+struct ApproxByInterpolation{Points <: AbstractVector} <: AbstractApproxMethod
+    xs :: Points
+end
+
+Base.show(io::IO, m::ApproxByInterpolation) =
+    print(io, "interpolation at ", m.xs)
+
+ApproxByInterpolation(B::AbstractBSplineBasis) =
+    ApproxByInterpolation(collocation_points(B))
+
+@doc raw"""
+    MinimiseL2Error <: AbstractApproxMethod
+
+Approximate a given function ``f(x)`` by minimisation of the ``L^2`` distance
+between ``f`` and its spline approximation ``g(x)``.
+
+# Extended help
+
+Minimises the ``L^2`` distance between the two functions:
+
+```math
+{\left\lVert f - g \right\rVert}^2 = \left< f - g, f - g \right>
+```
+
+where
+
+```math
+\left< u, v \right> = ∫_a^b u(x) \, v(x) \, \mathrm{d}x
+```
+
+is the inner product between two functions, and ``a`` and ``b`` are the
+boundaries of the prescribed B-spline basis.
+Here, ``g`` is the spline ``g(x) = ∑_{i = 1}^N c_i \, b_i(x)``, and
+``\{ b_i \}_{i = 1}^N`` is a prescribed B-spline basis.
+
+One can show that the optimal coefficients ``c_i`` minimising the ``L^2`` error
+are the solution to the linear system ``\bm{M} \bm{c} = \bm{φ}``,
+where ``M_{ij} = \left< b_i, b_j \right>`` (computed by [`galerkin_matrix`](@ref))
+and ``φ_i = \left< b_i, f \right>``.
+
+The integrals associated to ``\bm{M}`` and ``\bm{φ}`` are computed via
+Gauss--Legendre quadrature.
+The number of quadrature nodes is chosen as a function of the order ``k`` of the
+prescribed B-spline basis, ensuring that ``\bm{M}`` is computed exactly (see
+also [`galerkin_matrix`](@ref)).
+In the particular case where ``f`` is a polynomial of degree ``k - 1``, this
+also results in an exact computation of ``\bm{φ}``.
+In more general cases, as long as ``f`` is smooth enough, this is still expected
+to yield a very good approximation of the integral, and thus of the optimal coefficients ``c_i``.
+
+"""
+struct MinimiseL2Error <: AbstractApproxMethod end
+
+const MinimizeL2Error = MinimiseL2Error
+
+struct SplineApproximation{
+        ApproxSpline <: Spline,
+        Method <: AbstractApproxMethod,
+        Data,
+    } <: SplineWrapper{ApproxSpline}
+    method :: Method
+    spline :: ApproxSpline  # approximating spline
+    data   :: Data
+end
+
+method(a::SplineApproximation) = a.method
+SplineInterpolations.spline(a::SplineApproximation) = a.spline
+data(a::SplineApproximation) = a.data
+
+function Base.show(io::IO, A::SplineApproximation)
+    print(io, nameof(typeof(A)), " containing the ", spline(A))
+    print(io, "\n approximation method: ", method(A))
+    nothing
+end
+
+"""
+    approximate(f, B::AbstractBSplineBasis, [method = ApproxByInterpolation(B)])
+
+Approximate function `f` in the given basis, using the chosen method.
+
+From lower to higher accuracy (and cost), the possible approximation methods are:
+
+- [`VariationDiminishing`](@ref),
+- [`ApproxByInterpolation`](@ref),
+- [`MinimiseL2Error`](@ref).
+
+See their respective documentations for details.
+
+Note that, once an approximation has been performed, it's possible to
+efficiently perform additional approximations (of other functions `f`) by
+calling the in-place [`interpolate!`](@ref).
+This completely avoids allocations and strongly reduces computation time.
+
+# Examples
+
+```jldoctest
+julia> B = BSplineBasis(BSplineOrder(3), -1:0.4:1);
+
+julia> S_interp = approximate(sin, B)
+SplineApproximation containing the 7-element Spline{Float64}:
+ order: 3
+ knots: [-1.0, -1.0, -1.0, -0.6, -0.2, 0.2, 0.6, 1.0, 1.0, 1.0]
+ coefficients: [-0.8414709848078965, -0.7317273726556252, -0.39726989430226317, 0.0, 0.39726989430226317, 0.7317273726556252, 0.8414709848078965]
+ approximation method: interpolation at [-1.0, -0.8, -0.4, 0.0, 0.4, 0.8, 1.0]
+
+julia> sin(0.3), S_interp(0.3)
+(0.29552020666133955, 0.2959895327282942)
+
+julia> approximate!(exp, S_interp)
+SplineApproximation containing the 7-element Spline{Float64}:
+ order: 3
+ knots: [-1.0, -1.0, -1.0, -0.6, -0.2, 0.2, 0.6, 1.0, 1.0, 1.0]
+ coefficients: [0.36787944117144233, 0.4403725424224455, 0.6570101184826601, 0.9801271149667085, 1.4622271917170906, 2.181107315860912, 2.718281828459045]
+ approximation method: interpolation at [-1.0, -0.8, -0.4, 0.0, 0.4, 0.8, 1.0]
+
+julia> exp(0.3), S_interp(0.3)
+(1.3498588075760032, 1.3491015490105398)
+
+julia> S_fast = approximate(exp, B, VariationDiminishing())
+SplineApproximation containing the 7-element Spline{Float64}:
+ order: 3
+ knots: [-1.0, -1.0, -1.0, -0.6, -0.2, 0.2, 0.6, 1.0, 1.0, 1.0]
+ coefficients: [0.36787944117144233, 0.44932896411722156, 0.6703200460356393, 1.0, 1.4918246976412703, 2.225540928492468, 2.718281828459045]
+ approximation method: variation diminishing
+
+julia> x = 0.3; exp(x), S_interp(x), S_fast(x)
+(1.3498588075760032, 1.3491015490105398, 1.3764276336437629)
+```
+"""
+approximate(f, B::AbstractBSplineBasis) =
+    approximate(f, B, ApproxByInterpolation(B))
+
+"""
+    approximate!(f, A::SplineApproximation)
+
+Approximate function `f` reusing a previous Spline approximation in a given
+basis.
+
+See [`approximate`](@ref) for details.
+"""
+approximate!(f, A::SplineApproximation) = _approximate!(f, A, method(A))
+
+function approximate(f, B::AbstractBSplineBasis, m::ApproxByInterpolation)
+    S = SplineInterpolation(undef, B, m.xs)
+    A = SplineApproximation(m, spline(S), S)
+    approximate!(f, A)
+end
+
+function _approximate!(f, A::SplineApproximation, m::ApproxByInterpolation)
+    @assert method(A) === m
+    S = data(A)
+    xs = SplineInterpolations.interpolation_points(S)
+    @assert xs === method(A).xs
+    ys = coefficients(S)  # just to avoid allocating extra vector
+    map!(f, ys, xs)  # equivalent to ys .= f.(xs)
+    interpolate!(S, ys)
+    A
+end
+
+function approximate(f, B::AbstractBSplineBasis, m::VariationDiminishing)
+    S = Spline(undef, B)
+    A = SplineApproximation(m, S, nothing)
+    approximate!(f, A)
+end
+
+function _approximate!(f, A::SplineApproximation, m::VariationDiminishing)
+    @assert method(A) === m
+    # TODO
+    # - optimise window averaging operation
+    # - reuse code here and in collocation_points: define lazy iterator over
+    #   Greville sites?
+    # - does this work properly with recombined bases (-> shift index of first
+    #   knot)
+    S = spline(A)
+    N = length(S)
+    ts = knots(S)
+    k = order(S)
+    cs = coefficients(S)
+    degree = k - 1
+    T = float(eltype(ts))
+    @inbounds for i = 1:N
+        # Compute Greville site
+        x = zero(T)
+        for j = 1:degree
+            x += ts[i + j]
+        end
+        x /= degree
+        cs[i] = f(x)
+    end
+    A
+end
+
+end

--- a/src/SplineApproximations/SplineApproximations.jl
+++ b/src/SplineApproximations/SplineApproximations.jl
@@ -36,8 +36,6 @@ Abstract type describing a type of approximation method.
 """
 abstract type AbstractApproxMethod end
 
-Base.show(io::IO, m::AbstractApproxMethod) = print(io, nameof(typeof(m)))
-
 struct SplineApproximation{
         ApproxSpline <: Spline,
         Method <: AbstractApproxMethod,
@@ -106,10 +104,17 @@ SplineApproximation containing the 7-element Spline{Float64}:
  order: 3
  knots: [-1.0, -1.0, -1.0, -0.6, -0.2, 0.2, 0.6, 1.0, 1.0, 1.0]
  coefficients: [0.36787944117144233, 0.44932896411722156, 0.6703200460356393, 1.0, 1.4918246976412703, 2.225540928492468, 2.718281828459045]
- approximation method: variation diminishing
+ approximation method: VariationDiminishing()
 
-julia> x = 0.3; exp(x), S_interp(x), S_fast(x)
-(1.3498588075760032, 1.3491015490105398, 1.3764276336437629)
+julia> S_opt = approximate(exp, B, MinimiseL2Error())
+SplineApproximation containing the 7-element Spline{Float64}:
+ order: 3
+ knots: [-1.0, -1.0, -1.0, -0.6, -0.2, 0.2, 0.6, 1.0, 1.0, 1.0]
+ coefficients: [0.368073806165329, 0.4403423586370571, 0.6570767565347361, 0.9802789580270397, 1.4621592525088214, 2.182012185989042, 2.7166900724062018]
+ approximation method: MinimiseL2Error()
+
+julia> x = 0.34; exp(x), S_opt(x), S_interp(x), S_fast(x)
+(1.4049475905635938, 1.4044530324752085, 1.4044149581073815, 1.4328668494041878)
 ```
 """
 approximate(f, B::AbstractBSplineBasis) =

--- a/src/SplineApproximations/SplineApproximations.jl
+++ b/src/SplineApproximations/SplineApproximations.jl
@@ -25,7 +25,6 @@ export
     VariationDiminishing,
     ApproxByInterpolation,
     MinimiseL2Error,
-    MinimizeL2Error,
     approximate,
     approximate!
 

--- a/src/SplineApproximations/SplineApproximations.jl
+++ b/src/SplineApproximations/SplineApproximations.jl
@@ -8,7 +8,7 @@ best approximates a known function ``f(x)``.
 In other words, given a predefined [`BSplineBasis`](@ref), the objective is to
 find some appropriate B-spline coefficients such that the resulting spline
 appropriately approximates ``f``.
-Different approximation approaches are proposed, trading accuracy and speed.
+Different approximation approaches are implemented, trading accuracy and speed.
 """
 module SplineApproximations
 
@@ -37,112 +37,6 @@ Abstract type describing a type of approximation method.
 abstract type AbstractApproxMethod end
 
 Base.show(io::IO, m::AbstractApproxMethod) = print(io, nameof(typeof(m)))
-
-"""
-    VariationDiminishing <: AbstractApproxMethod
-
-Schoenberg's variation diminishing spline approximation.
-
-Approximates a function ``f`` by setting the B-spline coefficients as
-``c_i = f(x_i)``, where the locations ``x_i`` are chosen as the Greville sites:
-
-```math
-x_i = \\frac{1}{k - 1} ∑_{j = 1}^{k - 1} t_{i + j}
-```
-
-This method is expected to provide a decent low-accuracy approximation of the
-function ``f`` .
-For details, see e.g. de Boor 2001, chapter XI.
-
-!!! warning
-
-    Currently, this method is not guaranteed to work well with recombined
-    B-spline bases (of type [`RecombinedBSplineBasis`](@ref)).
-
-"""
-struct VariationDiminishing <: AbstractApproxMethod end
-
-Base.show(io::IO, ::VariationDiminishing) = print(io, "variation diminishing")
-
-"""
-    ApproxByInterpolation <: AbstractApproxMethod
-
-Approximate function by a spline that passes through the given set of points.
-
-The number of points must be equal to the length of the B-spline basis defining
-the approximation space.
-
-See belows for different ways of specifying the interpolation points.
-
----
-
-    ApproxByInterpolation(xs::AbstractVector)
-
-Specifies an approximation by interpolation at the given points `xs`.
-
----
-
-    ApproxByInterpolation(B::AbstractBSplineBasis)
-
-Specifies an approximation by interpolation at an automatically-determined set
-of points, which are expected to be appropriate for the given basis.
-
-The interpolation points are determined by calling [`collocation_points`](@ref).
-"""
-struct ApproxByInterpolation{Points <: AbstractVector} <: AbstractApproxMethod
-    xs :: Points
-end
-
-Base.show(io::IO, m::ApproxByInterpolation) =
-    print(io, "interpolation at ", m.xs)
-
-ApproxByInterpolation(B::AbstractBSplineBasis) =
-    ApproxByInterpolation(collocation_points(B))
-
-@doc raw"""
-    MinimiseL2Error <: AbstractApproxMethod
-
-Approximate a given function ``f(x)`` by minimisation of the ``L^2`` distance
-between ``f`` and its spline approximation ``g(x)``.
-
-# Extended help
-
-Minimises the ``L^2`` distance between the two functions:
-
-```math
-{\left\lVert f - g \right\rVert}^2 = \left< f - g, f - g \right>
-```
-
-where
-
-```math
-\left< u, v \right> = ∫_a^b u(x) \, v(x) \, \mathrm{d}x
-```
-
-is the inner product between two functions, and ``a`` and ``b`` are the
-boundaries of the prescribed B-spline basis.
-Here, ``g`` is the spline ``g(x) = ∑_{i = 1}^N c_i \, b_i(x)``, and
-``\{ b_i \}_{i = 1}^N`` is a prescribed B-spline basis.
-
-One can show that the optimal coefficients ``c_i`` minimising the ``L^2`` error
-are the solution to the linear system ``\bm{M} \bm{c} = \bm{φ}``,
-where ``M_{ij} = \left< b_i, b_j \right>`` (computed by [`galerkin_matrix`](@ref))
-and ``φ_i = \left< b_i, f \right>``.
-
-The integrals associated to ``\bm{M}`` and ``\bm{φ}`` are computed via
-Gauss--Legendre quadrature.
-The number of quadrature nodes is chosen as a function of the order ``k`` of the
-prescribed B-spline basis, ensuring that ``\bm{M}`` is computed exactly (see
-also [`galerkin_matrix`](@ref)).
-In the particular case where ``f`` is a polynomial of degree ``k - 1``, this
-also results in an exact computation of ``\bm{φ}``.
-In more general cases, as long as ``f`` is smooth enough, this is still expected
-to yield a very good approximation of the integral, and thus of the optimal coefficients ``c_i``.
-
-"""
-struct MinimiseL2Error <: AbstractApproxMethod end
-
-const MinimizeL2Error = MinimiseL2Error
 
 struct SplineApproximation{
         ApproxSpline <: Spline,
@@ -231,54 +125,8 @@ See [`approximate`](@ref) for details.
 """
 approximate!(f, A::SplineApproximation) = _approximate!(f, A, method(A))
 
-function approximate(f, B::AbstractBSplineBasis, m::ApproxByInterpolation)
-    S = SplineInterpolation(undef, B, m.xs)
-    A = SplineApproximation(m, spline(S), S)
-    approximate!(f, A)
-end
-
-function _approximate!(f, A::SplineApproximation, m::ApproxByInterpolation)
-    @assert method(A) === m
-    S = data(A)
-    xs = SplineInterpolations.interpolation_points(S)
-    @assert xs === method(A).xs
-    ys = coefficients(S)  # just to avoid allocating extra vector
-    map!(f, ys, xs)  # equivalent to ys .= f.(xs)
-    interpolate!(S, ys)
-    A
-end
-
-function approximate(f, B::AbstractBSplineBasis, m::VariationDiminishing)
-    S = Spline(undef, B)
-    A = SplineApproximation(m, S, nothing)
-    approximate!(f, A)
-end
-
-function _approximate!(f, A::SplineApproximation, m::VariationDiminishing)
-    @assert method(A) === m
-    # TODO
-    # - optimise window averaging operation
-    # - reuse code here and in collocation_points: define lazy iterator over
-    #   Greville sites?
-    # - does this work properly with recombined bases (-> shift index of first
-    #   knot)
-    S = spline(A)
-    N = length(S)
-    ts = knots(S)
-    k = order(S)
-    cs = coefficients(S)
-    degree = k - 1
-    T = float(eltype(ts))
-    @inbounds for i = 1:N
-        # Compute Greville site
-        x = zero(T)
-        for j = 1:degree
-            x += ts[i + j]
-        end
-        x /= degree
-        cs[i] = f(x)
-    end
-    A
-end
+include("variation_diminishing.jl")
+include("by_interpolation.jl")
+include("minimiseL2.jl")
 
 end

--- a/src/SplineApproximations/by_interpolation.jl
+++ b/src/SplineApproximations/by_interpolation.jl
@@ -45,7 +45,9 @@ function _approximate!(f, A, m::ApproxByInterpolation)
     xs = SplineInterpolations.interpolation_points(S)
     @assert xs === method(A).xs
     ys = coefficients(S)  # just to avoid allocating extra vector
-    map!(f, ys, xs)  # equivalent to ys .= f.(xs)
+    @inbounds for i in eachindex(xs, ys)
+        ys[i] = f(xs[i])
+    end
     interpolate!(S, ys)
     A
 end

--- a/src/SplineApproximations/by_interpolation.jl
+++ b/src/SplineApproximations/by_interpolation.jl
@@ -1,0 +1,51 @@
+"""
+    ApproxByInterpolation <: AbstractApproxMethod
+
+Approximate function by a spline that passes through the given set of points.
+
+The number of points must be equal to the length of the B-spline basis defining
+the approximation space.
+
+See belows for different ways of specifying the interpolation points.
+
+---
+
+    ApproxByInterpolation(xs::AbstractVector)
+
+Specifies an approximation by interpolation at the given points `xs`.
+
+---
+
+    ApproxByInterpolation(B::AbstractBSplineBasis)
+
+Specifies an approximation by interpolation at an automatically-determined set
+of points, which are expected to be appropriate for the given basis.
+
+The interpolation points are determined by calling [`collocation_points`](@ref).
+"""
+struct ApproxByInterpolation{Points <: AbstractVector} <: AbstractApproxMethod
+    xs :: Points
+end
+
+Base.show(io::IO, m::ApproxByInterpolation) =
+    print(io, "interpolation at ", m.xs)
+
+ApproxByInterpolation(B::AbstractBSplineBasis) =
+    ApproxByInterpolation(collocation_points(B))
+
+function approximate(f, B::AbstractBSplineBasis, m::ApproxByInterpolation)
+    S = SplineInterpolation(undef, B, m.xs)
+    A = SplineApproximation(m, spline(S), S)
+    approximate!(f, A)
+end
+
+function _approximate!(f, A, m::ApproxByInterpolation)
+    @assert method(A) === m
+    S = data(A)
+    xs = SplineInterpolations.interpolation_points(S)
+    @assert xs === method(A).xs
+    ys = coefficients(S)  # just to avoid allocating extra vector
+    map!(f, ys, xs)  # equivalent to ys .= f.(xs)
+    interpolate!(S, ys)
+    A
+end

--- a/src/SplineApproximations/minimiseL2.jl
+++ b/src/SplineApproximations/minimiseL2.jl
@@ -1,0 +1,44 @@
+@doc raw"""
+    MinimiseL2Error <: AbstractApproxMethod
+
+Approximate a given function ``f(x)`` by minimisation of the ``L^2`` distance
+between ``f`` and its spline approximation ``g(x)``.
+
+# Extended help
+
+Minimises the ``L^2`` distance between the two functions:
+
+```math
+{\left\lVert f - g \right\rVert}^2 = \left< f - g, f - g \right>
+```
+
+where
+
+```math
+\left< u, v \right> = ∫_a^b u(x) \, v(x) \, \mathrm{d}x
+```
+
+is the inner product between two functions, and ``a`` and ``b`` are the
+boundaries of the prescribed B-spline basis.
+Here, ``g`` is the spline ``g(x) = ∑_{i = 1}^N c_i \, b_i(x)``, and
+``\{ b_i \}_{i = 1}^N`` is a prescribed B-spline basis.
+
+One can show that the optimal coefficients ``c_i`` minimising the ``L^2`` error
+are the solution to the linear system ``\bm{M} \bm{c} = \bm{φ}``,
+where ``M_{ij} = \left< b_i, b_j \right>`` (computed by [`galerkin_matrix`](@ref))
+and ``φ_i = \left< b_i, f \right>``.
+
+The integrals associated to ``\bm{M}`` and ``\bm{φ}`` are computed via
+Gauss--Legendre quadrature.
+The number of quadrature nodes is chosen as a function of the order ``k`` of the
+prescribed B-spline basis, ensuring that ``\bm{M}`` is computed exactly (see
+also [`galerkin_matrix`](@ref)).
+In the particular case where ``f`` is a polynomial of degree ``k - 1``, this
+also results in an exact computation of ``\bm{φ}``.
+In more general cases, as long as ``f`` is smooth enough, this is still expected
+to yield a very good approximation of the integral, and thus of the optimal coefficients ``c_i``.
+
+"""
+struct MinimiseL2Error <: AbstractApproxMethod end
+
+const MinimizeL2Error = MinimiseL2Error

--- a/src/SplineApproximations/variation_diminishing.jl
+++ b/src/SplineApproximations/variation_diminishing.jl
@@ -1,0 +1,59 @@
+"""
+    VariationDiminishing <: AbstractApproxMethod
+
+Schoenberg's variation diminishing spline approximation.
+
+Approximates a function ``f`` by setting the B-spline coefficients as
+``c_i = f(x_i)``, where the locations ``x_i`` are chosen as the Greville sites:
+
+```math
+x_i = \\frac{1}{k - 1} ∑_{j = 1}^{k - 1} t_{i + j}.
+```
+
+This method is expected to preserve the shape of the function.
+However, it may be very inaccurate as an actual approximation of it.
+
+For details, see e.g. de Boor 2001, chapter XI.
+
+!!! warning
+
+    Currently, this method is not guaranteed to work well with recombined
+    B-spline bases (of type [`RecombinedBSplineBasis`](@ref)).
+
+"""
+struct VariationDiminishing <: AbstractApproxMethod end
+
+Base.show(io::IO, ::VariationDiminishing) = print(io, "variation diminishing")
+
+function approximate(f, B::AbstractBSplineBasis, m::VariationDiminishing)
+    S = Spline(undef, B)
+    A = SplineApproximation(m, S, nothing)
+    approximate!(f, A)
+end
+
+function _approximate!(f, A, m::VariationDiminishing)
+    @assert method(A) === m
+    # TODO
+    # - optimise window averaging operation
+    # - reuse code here and in collocation_points: define lazy iterator over
+    #   Greville sites?
+    # - does this work properly with recombined bases (-> shift index of first
+    #   knot)
+    S = spline(A)
+    N = length(S)
+    ts = knots(S)
+    k = order(S)
+    cs = coefficients(S)
+    degree = k - 1
+    T = float(eltype(ts))
+    @inbounds for i = 1:N
+        # Compute Greville site
+        x = zero(T)
+        for j = 1:degree
+            x += ts[i + j]
+        end
+        x /= degree
+        cs[i] = f(x)
+    end
+    A
+end

--- a/src/SplineApproximations/variation_diminishing.jl
+++ b/src/SplineApproximations/variation_diminishing.jl
@@ -23,10 +23,9 @@ For details, see e.g. de Boor 2001, chapter XI.
 """
 struct VariationDiminishing <: AbstractApproxMethod end
 
-Base.show(io::IO, ::VariationDiminishing) = print(io, "variation diminishing")
-
 function approximate(f, B::AbstractBSplineBasis, m::VariationDiminishing)
-    S = Spline(undef, B)
+    T = typeof(f(first(knots(B))))
+    S = Spline{T}(undef, B)
     A = SplineApproximation(m, S, nothing)
     approximate!(f, A)
 end

--- a/src/Splines/Splines.jl
+++ b/src/Splines/Splines.jl
@@ -1,6 +1,13 @@
 module Splines
 
-export Spline, coefficients, integral
+export
+    Spline,
+    coefficients,
+    integral
+
+export
+    SplineWrapper,
+    spline
 
 using Base.Cartesian: @nexprs
 
@@ -10,5 +17,6 @@ using ..DifferentialOps
 import ..BSplines: basis, knots, order
 
 include("spline.jl")
+include("wrapper.jl")
 
 end

--- a/src/Splines/spline.jl
+++ b/src/Splines/spline.jl
@@ -25,7 +25,7 @@ julia> S = Spline(B, coefs)
 
 ---
 
-    Spline(undef, B::AbstractBSplineBasis, [T=Float64])
+    Spline{T = Float64}(undef, B::AbstractBSplineBasis)
 
 Construct a spline with uninitialised vector of coefficients.
 
@@ -74,11 +74,16 @@ Base.isapprox(P::Spline, Q::Spline; kwargs...) =
     basis(P) == basis(Q) &&
     isapprox(coefficients(P), coefficients(Q); kwargs...)
 
-function Spline(::UndefInitializer, B::AbstractBSplineBasis,
-                ::Type{T}=Float64) where {T}
-    coefs = Vector{T}(undef, length(B))
+function Spline{T}(init, B::AbstractBSplineBasis) where {T}
+    coefs = Vector{T}(init, length(B))
     Spline(B, coefs)
 end
+
+Spline(init, B::AbstractBSplineBasis) = Spline{Float64}(init, B)
+
+# TODO deprecate?
+Spline(init, B::AbstractBSplineBasis, ::Type{T}) where {T} =
+    Spline{T}(init, B)
 
 parent_spline(S::Spline) = parent_spline(basis(S), S)
 parent_spline(::BSplineBasis, S::Spline) = S

--- a/src/Splines/spline.jl
+++ b/src/Splines/spline.jl
@@ -100,11 +100,12 @@ Note that this is equal to the number of basis functions, `length(basis(S))`.
 Base.length(S::Spline) = length(coefficients(S))
 
 """
+    eltype(::Type{<:Spline})
     eltype(S::Spline)
 
 Returns type of element returned when evaluating the [`Spline`](@ref).
 """
-Base.eltype(S::Spline{T}) where {T} = T
+Base.eltype(::Type{<:Spline{T}}) where {T} = T
 
 """
     basis(S::Spline) -> AbstractBSplineBasis

--- a/src/Splines/wrapper.jl
+++ b/src/Splines/wrapper.jl
@@ -1,0 +1,25 @@
+"""
+    SplineWrapper{S <: Spline}
+
+Abstract type representing a type that wraps a [`Spline`](@ref).
+
+Such a type implements all common operations on splines, including evaluation,
+differentiation, etc…
+"""
+abstract type SplineWrapper{S} end
+
+"""
+    spline(w::SplineWrapper) -> Spline
+
+Returns the [`Spline`](@ref) wrapped by the object.
+"""
+spline(w::SplineWrapper) = w.spline
+
+Base.eltype(::Type{<:SplineWrapper{S}}) where {S} = eltype(S)
+
+(I::SplineWrapper)(x) = spline(I)(x)
+Base.diff(I::SplineWrapper, etc...) = diff(spline(I), etc...)
+
+for f in (:basis, :order, :knots, :coefficients, :integral)
+    @eval $f(I::SplineWrapper) = $f(spline(I))
+end

--- a/src/Splines/wrapper.jl
+++ b/src/Splines/wrapper.jl
@@ -6,7 +6,7 @@ Abstract type representing a type that wraps a [`Spline`](@ref).
 Such a type implements all common operations on splines, including evaluation,
 differentiation, etc…
 """
-abstract type SplineWrapper{S} end
+abstract type SplineWrapper{S <: Spline} end
 
 """
     spline(w::SplineWrapper) -> Spline

--- a/test/approximation.jl
+++ b/test/approximation.jl
@@ -1,0 +1,40 @@
+using BSplineKit
+using Test
+
+function test_approximation(B)
+    k = order(B)
+
+    fpoly = let poly_coefs = ntuple(d -> (-d)^d, Val(k))
+        x -> @eval_poly(x, poly_coefs...)
+    end
+
+    f_fast = approximate(fpoly, B, VariationDiminishing())
+
+    # @test repr(f_fast)
+
+    # With these two methods, the approximation should exactly match a
+    # polynomial of degree k - 1.
+    f_interp = approximate(fpoly, B, ApproxByInterpolation(B))
+
+    # TODO test this method...
+    # f_opt = approximate(fpoly, B, MinimiseL2Error(B))
+
+    # xfine = range(first(x), last(x); length = 2 * length(x))
+    # @test fapprox.(xfine) ≈ fpoly.(xfine)
+end
+
+# TODO
+# - test a couple of orders
+# - test the 3 approximation methods
+# - test in-place approximation
+# - test show(::SplineApproximation)
+# - test recombined basis (test function should satisfy BCs...)
+@testset "Approximation" begin
+    N = 16
+    breaks = [-cos(π * n / N) for n = 0:N]
+    @testset "Order $k" for k = 4:5
+        B = BSplineBasis(BSplineOrder(k), copy(breaks))
+        # R = RecombinedBSplineBasis(B, Derivative(1))  # Neumann BCs
+        test_approximation(B)
+    end
+end

--- a/test/approximation.jl
+++ b/test/approximation.jl
@@ -1,34 +1,52 @@
 using BSplineKit
 using Test
 
+# TODO
+# - test recombined basis (test function should satisfy BCs...)
+
+function check_approximate_in_place!(f, fapprox)
+    S = copy(spline(fapprox))  # assumed to already approximate `f`
+    @test 32 ≥ @allocated approximate!(f, fapprox)  # (almost) no allocations!
+    @test spline(fapprox) == S  # check that nothing changed
+    nothing
+end
+
 function test_approximation(B)
     k = order(B)
 
-    fpoly = let poly_coefs = ntuple(d -> (-d)^d, Val(k))
-        x -> @eval_poly(x, poly_coefs...)
-    end
+    ftest = sin
 
-    f_fast = approximate(fpoly, B, VariationDiminishing())
-
-    # @test repr(f_fast)
+    f_fast = @inferred approximate(ftest, B, VariationDiminishing())
+    @test startswith(repr(f_fast), "SplineApproximation containing")
+    check_approximate_in_place!(ftest, f_fast)
 
     # With these two methods, the approximation should exactly match a
     # polynomial of degree k - 1.
-    f_interp = approximate(fpoly, B, ApproxByInterpolation(B))
+    f_interp = @inferred approximate(ftest, B, ApproxByInterpolation(B))
+    @test startswith(repr(f_interp), "SplineApproximation containing")
+    check_approximate_in_place!(ftest, f_interp)
 
-    # TODO test this method...
-    # f_opt = approximate(fpoly, B, MinimiseL2Error(B))
+    f_opt = @inferred approximate(ftest, B, MinimiseL2Error())
+    @test startswith(repr(f_opt), "SplineApproximation containing")
+    check_approximate_in_place!(ftest, f_opt)
 
-    # xfine = range(first(x), last(x); length = 2 * length(x))
-    # @test fapprox.(xfine) ≈ fpoly.(xfine)
+    # Polynomial of degree k - 1.
+    # The interpolation and minimisation methods should exactly approximate such
+    # a polynomial.
+    poly_coefs = ntuple(d -> (-d)^d, Val(k))
+    fpoly(x) = evalpoly(x, poly_coefs)
+
+    xfine = range(boundaries(B)...; length = 3 * length(B))
+
+    approximate!(fpoly, f_interp)
+    @test fpoly.(xfine) ≈ f_interp.(xfine)
+
+    approximate!(fpoly, f_opt)
+    @test fpoly.(xfine) ≈ f_opt.(xfine)
+
+    nothing
 end
 
-# TODO
-# - test a couple of orders
-# - test the 3 approximation methods
-# - test in-place approximation
-# - test show(::SplineApproximation)
-# - test recombined basis (test function should satisfy BCs...)
 @testset "Approximation" begin
     N = 16
     breaks = [-cos(π * n / N) for n = 0:N]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ gauss_lobatto_points(N) = [-cos(π * n / N) for n = 0:N]
 include("diffops.jl")
 include("knots.jl")
 include("splines.jl")
+include("approximation.jl")
 include("recombination.jl")
 include("collocation.jl")
 include("galerkin.jl")

--- a/test/splines.jl
+++ b/test/splines.jl
@@ -26,13 +26,6 @@ function test_polynomial(x, ::BSplineOrder{k}) where {k}
     S = spline(itp)
     @test length(S) == length(x)
 
-    @testset "Function approximations" begin
-        fpoly(x) = eval_poly(x, P)
-        fapprox = approximate(fpoly, basis(S))
-        xfine = range(first(x), last(x); length = 2 * length(x))
-        @test fapprox.(xfine) ≈ fpoly.(xfine)
-    end
-
     @testset "Interpolations" begin
         @test itp.(x) ≈ y
 


### PR DESCRIPTION
We now propose 3 different function approximation methods, of different accuracy and speed.

To do:

- [ ] Define iterator over Greville sites
  * optimise window averaging operation
  * take into account basis recombination (-> shift initial knot)
  * use iterator in `collocation_points` and in the fast approximation method
- [x] Implement `MinimiseL2Error` method
- [x] Tests
- [x] Example