### PR TITLE
Much faster evaluation of basis functions

### DIFF
--- a/src/BSplines/knots.jl
+++ b/src/BSplines/knots.jl
@@ -26,7 +26,7 @@ Base.IndexStyle(::Type{<:AugmentedKnots}) = IndexLinear()
 
 # Custom definition of searchsortedlast, for sligthly faster determination of
 # the knot interval corresponding to a given point `x` (used when evaluating
-# splines; see `Splines.knot_interval`).
+# splines; see `knot_interval`).
 # TODO does this actually improve performance??
 function Base.searchsortedlast(t::AugmentedKnots, x; kws...)
     ξ = breakpoints(t)
@@ -107,4 +107,22 @@ function multiplicity(knots::AbstractVector, i)
     end
 
     m
+end
+
+function knot_interval(t::AbstractVector, x)
+    n = searchsortedlast(t, x)  # t[n] <= x < t[n + 1]
+    n == 0 && return nothing    # x < t[1]
+
+    Nt = length(t)
+
+    if n == Nt  # i.e. if x >= t[end]
+        t_last = t[n]
+        x > t_last && return nothing
+        # If x is exactly on the last knot, decrease the index as necessary.
+        while t[n] == t_last
+            n -= one(n)
+        end
+    end
+
+    n
 end

--- a/src/Recombinations/matrices.jl
+++ b/src/Recombinations/matrices.jl
@@ -272,7 +272,7 @@ num_recombined(::UniformScaling) = (0, 0)
 @inline function which_recombine_block(A::RecombineMatrix, j)
     @boundscheck checkbounds(A, :, j)
     M = A.M
-    nl, nr = num_recombined(A)  # left/right number of recombined bases
+    nl, nr = num_recombined(A)  # left/right number of recombined basis functions
     j <= nl && return 1
     j > M - nr && return 3
     2

--- a/src/Splines/Splines.jl
+++ b/src/Splines/Splines.jl
@@ -15,6 +15,7 @@ using ..BSplines
 using ..DifferentialOps
 
 import ..BSplines: basis, knots, order
+using ..BSplines: knot_interval
 
 include("spline.jl")
 include("wrapper.jl")

--- a/src/Splines/spline.jl
+++ b/src/Splines/spline.jl
@@ -276,21 +276,3 @@ function _integral(::BSplineBasis, S::Spline)
     B = BSplineBasis(BSplineOrder(k + 1), t_int; augment = Val(false))
     Spline(B, β)
 end
-
-function knot_interval(t::AbstractVector, x)
-    n = searchsortedlast(t, x)  # t[n] <= x < t[n + 1]
-    n == 0 && return nothing    # x < t[1]
-
-    Nt = length(t)
-
-    if n == Nt  # i.e. if x >= t[end]
-        t_last = t[n]
-        x > t_last && return nothing
-        # If x is exactly on the last knot, decrease the index as necessary.
-        while t[n] == t_last
-            n -= one(n)
-        end
-    end
-
-    n
-end


### PR DESCRIPTION
**UPDATE**: this PR is replaced by #35. The performance is the same, but the implementation in #35 is more complete (derivatives are also included) while also being more readable.

---

Optimise evaluation of B-splines and recombined basis functions, following de Boor's algorithms. 

Note that this doesn't affect evaluation of splines, which are already very fast (also using de Boor's algorithm).

This affects other operations such as the computation of Galerkin matrices and projections via quadratures, which are much faster now.

To do:

- [x] Implement `evaluate_all` for B-splines
- [x] Implement `evaluate_all` for recombined basis functions
- [ ] Implement `evaluate_all` for derivatives
- [ ] Use `evaluate_all` for Galerkin operations...
  - [x]  for basis functions
  - [ ] for derivatives of basis functions
- [ ] Use `evaluate_all` for construction of collocation matrices
- [ ] Add tests comparing results of `evaluate_all` and previous implementation