### PR TITLE
Add alternative notation for derivation of splines

### DIFF
--- a/docs/src/splines.md
+++ b/docs/src/splines.md
@@ -17,6 +17,7 @@ basis(::Spline)
 ## Derivatives and integrals
 
 ```@docs
+*
 diff
 integral
 ```

--- a/src/DifferentialOps/DifferentialOps.jl
+++ b/src/DifferentialOps/DifferentialOps.jl
@@ -86,6 +86,12 @@ Specifies the `n`-th derivative of a function.
 struct Derivative{n} <: AbstractDifferentialOp end
 
 Derivative(n::Integer) = Derivative{n}()
+Derivative() = Derivative(1)
+
+function Base.literal_pow(::typeof(^), op::Derivative{n}, ::Val{p}) where {n,p}
+    Derivative(n * p)
+end
+
 max_order(::Derivative{n}) where {n} = n
 
 # We return a ScaledDerivative for type stability.

--- a/src/Splines/spline.jl
+++ b/src/Splines/spline.jl
@@ -183,11 +183,46 @@ function spline_kernel(
 end
 
 """
-    diff(S::Spline, [deriv::Derivative = Derivative(1)]) -> Spline
+    *(op::Derivative, S::Spline) -> Spline
 
-Return `N`-th derivative of spline `S` as a new spline.
+Returns `N`-th derivative of spline `S` as a new spline.
+
+See also [`diff`](@ref).
+
+# Examples
+
+```jldoctest; filter = r"coefficients: \\[.*\\]"
+julia> B = BSplineBasis(BSplineOrder(4), -1:0.2:1);
+
+julia> S = Spline(B, rand(length(B)))
+13-element Spline{Float64}:
+ order: 4
+ knots: [-1.0, -1.0, -1.0, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.0, 1.0, 1.0]
+ coefficients: [0.411779, 0.477218, 0.602547, 0.30413, 0.304017, 0.750247, 0.614036, 0.519966, 0.657764, 0.437818, 0.107356, 0.429024, 0.435861]
+
+julia> Derivative(1) * S
+12-element Spline{Float64}:
+ order: 3
+ knots: [-1.0, -1.0, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.0, 1.0]
+ coefficients: [0.981589, 0.939965, -1.49208, -0.000564486, 2.23115, -0.681057, -0.470348, 0.688991, -1.09973, -1.65231, 2.41251, 0.102554]
+
+julia> Derivative(2) * S
+11-element Spline{Float64}:
+ order: 2
+ knots: [-1.0, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.0]
+ coefficients: [-0.416237, -12.1602, 7.45759, 11.1586, -14.561, 1.05354, 5.7967, -8.94361, -2.7629, 20.3241, -23.0995]
+```
 """
-Base.diff(S::Spline, deriv = Derivative(1)) = _diff(basis(S), S, deriv)
+Base.:*(op::Derivative, S::Spline) = _diff(basis(S), S, op)
+
+"""
+    diff(S::Spline, [op::Derivative = Derivative(1)]) -> Spline
+
+Same as `op * S`.
+
+Returns `N`-th derivative of spline `S` as a new spline.
+"""
+Base.diff(S::Spline, op = Derivative(1)) = op * S
 
 _diff(::AbstractBSplineBasis, S, etc...) = diff(parent_spline(S), etc...)
 

--- a/src/Splines/wrapper.jl
+++ b/src/Splines/wrapper.jl
@@ -19,6 +19,7 @@ Base.eltype(::Type{<:SplineWrapper{S}}) where {S} = eltype(S)
 
 (I::SplineWrapper)(x) = spline(I)(x)
 Base.diff(I::SplineWrapper, etc...) = diff(spline(I), etc...)
+Base.:*(op::Derivative, I::SplineWrapper) = op * spline(I)
 
 for f in (:basis, :order, :knots, :coefficients, :integral)
     @eval $f(I::SplineWrapper) = $f(spline(I))

--- a/test/diffops.jl
+++ b/test/diffops.jl
@@ -7,6 +7,15 @@ using LinearAlgebra: ⋅
     @test max_order(D2) == 2
     @test max_order(D3) == 3
 
+    @test D2^2 === Derivative(4)
+    @test D2^3 === Derivative(6)
+    @test Derivative() === Derivative(1)
+    @test Derivative()^3 === Derivative(3)
+
+    @inferred (() -> Derivative())()
+    @inferred (() -> Derivative()^3)()
+    @inferred (() -> Derivative(3))()
+
     S = D2 + 5 * D3
     S′ = 5 * D3 + D2
     @test S == S′

--- a/test/splines.jl
+++ b/test/splines.jl
@@ -38,7 +38,7 @@ function test_polynomial(x, ::BSplineOrder{k}) where {k}
         @test knots(itp) === knots(S)
         @test coefficients(itp) === coefficients(S)
         @test integral(itp) == integral(S)
-        @test diff(itp, Derivative(1)) == diff(S, Derivative(1))
+        @test diff(itp, Derivative(1)) == diff(S, Derivative(1)) == Derivative() * itp
 
         # "incompatible lengths of B-spline basis and collocation points"
         @test_throws(
@@ -57,6 +57,7 @@ function test_polynomial(x, ::BSplineOrder{k}) where {k}
     end
 
     S′ = diff(S, Derivative(1))
+    @test Derivative() * S == S′  # alternative notation
     Sint = integral(S)
 
     a, b = boundaries(basis(S))


### PR DESCRIPTION
Now the notation `Derivative(n) * spline` is the same as `diff(spline, Derivative(n)`.

Moreover, `Derivative()` is equivalent to `Derivative(1)`, and `Derivative(n)^p` is the same as `Derivative(n * p)`.