### PR TITLE
Faster evaluation of B-splines

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -66,5 +66,5 @@ end
 deploydocs(
     repo = "github.com/jipolanco/BSplineKit.jl",
     forcepush = true,
-    push_preview = true,  # PRs deploy at https://jipolanco.github.io/BSplineKit.jl/previews/PR##
+    push_preview = true,  # PRs deploy at https://jipolanco.github.io/BSplineKit.jl/previews/PR??
 )

--- a/docs/src/bsplines.md
+++ b/docs/src/bsplines.md
@@ -26,6 +26,7 @@ length(::BSplineBasis)
 BasisFunction
 support
 common_support
+find_knot_interval
 evaluate_all
 evaluate
 evaluate!

--- a/docs/src/bsplines.md
+++ b/docs/src/bsplines.md
@@ -26,6 +26,7 @@ length(::BSplineBasis)
 BasisFunction
 support
 common_support
+evaluate_all
 evaluate
 evaluate!
 nonzero_in_segment

--- a/src/BSplines/BSplines.jl
+++ b/src/BSplines/BSplines.jl
@@ -16,6 +16,7 @@ export
     basis,
     evaluate,
     evaluate!,
+    evaluate_all,
     nonzero_in_segment,
     support
 
@@ -43,5 +44,6 @@ struct BSplineOrder{k} end
 include("basis.jl")
 include("basis_function.jl")
 include("knots.jl")
+include("evaluate_all.jl")
 
 end

--- a/src/BSplines/BSplines.jl
+++ b/src/BSplines/BSplines.jl
@@ -29,8 +29,52 @@ Abstract type defining a B-spline basis, or more generally, a functional basis
 defined from B-splines.
 
 The basis is represented by a B-spline order `k` and a knot element type `T`.
+
+---
+
+    (B::AbstractBSplineBasis)(
+        x::Real, [op = Derivative(0)], [T = float(typeof(x))];
+        [ileft = nothing],
+    ) -> (i, bs)
+
+Evaluates all basis functions which are non-zero at `x`.
+
+This is a convenience alias for `evaluate_all`.
+See [`evaluate_all`](@ref) for details on optional arguments and on the returned values.
+
+# Examples
+
+```jldoctest
+julia> B = BSplineBasis(BSplineOrder(4), -1:0.1:1)
+23-element BSplineBasis of order 4, domain [-1.0, 1.0]
+ knots: [-1.0, -1.0, -1.0, -1.0, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4  …  0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0, 1.0]
+
+julia> i, bs = B(0.42)
+(18, (0.0013333333333333268, 0.28266666666666657, 0.6306666666666667, 0.08533333333333339))
+
+julia> sum(bs)
+1.0
+
+julia> bs[1] - B[i](0.42)
+0.0
+
+julia> bs[2] - B[i - 1](0.42)
+-5.551115123125783e-17
+
+julia> B(0.44; ileft = i)
+(18, (0.01066666666666666, 0.4146666666666667, 0.5386666666666665, 0.03599999999999999))
+
+julia> B(0.42, Float32)
+(18, (0.0013333336f0, 0.28266668f0, 0.6306667f0, 0.085333325f0))
+
+julia> B(0.42, Derivative(1))
+(18, (0.19999999999999937, 6.4, -3.3999999999999977, -3.200000000000001))
+```
 """
 abstract type AbstractBSplineBasis{k,T} end
+
+@inline (B::AbstractBSplineBasis)(args...; kws...) =
+    evaluate_all(B, args...; kws...)
 
 """
     BSplineOrder(k::Integer)

--- a/src/BSplines/basis.jl
+++ b/src/BSplines/basis.jl
@@ -118,48 +118,6 @@ julia> B[6](-0.5, Derivative(1))
     BasisFunction(B, i, T)
 end
 
-"""
-    (B::AbstractBSplineBasis)(
-        x::Real, [op = Derivative(0)], [T = float(typeof(x))];
-        [ileft = nothing],
-    ) -> (i, bs)
-
-Evaluates all basis functions which are non-zero at `x`.
-
-See [`evaluate_all`](@ref) for details on optional arguments and on the returned values.
-
-# Examples
-
-```jldoctest
-julia> B = BSplineBasis(BSplineOrder(4), -1:0.1:1)
-23-element BSplineBasis of order 4, domain [-1.0, 1.0]
- knots: [-1.0, -1.0, -1.0, -1.0, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4  …  0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0, 1.0]
-
-julia> i, bs = B(0.42)
-(18, (0.0013333333333333268, 0.28266666666666657, 0.6306666666666667, 0.08533333333333339))
-
-julia> sum(bs)
-1.0
-
-julia> bs[1] - B[i](0.42)
-0.0
-
-julia> bs[2] - B[i - 1](0.42)
--5.551115123125783e-17
-
-julia> B(0.44; ileft = i)
-(18, (0.01066666666666666, 0.4146666666666667, 0.5386666666666665, 0.03599999999999999))
-
-julia> B(0.42, Float32)
-(18, (0.0013333336f0, 0.28266668f0, 0.6306667f0, 0.085333325f0))
-
-julia> B(0.42, Derivative(1))
-(18, (0.19999999999999937, 6.4, -3.3999999999999977, -3.200000000000001))
-```
-"""
-@inline (B::AbstractBSplineBasis)(args...; kws...) =
-    evaluate_all(B, args...; kws...)
-
 @inline function Base.checkbounds(B::AbstractBSplineBasis, I)
     checkbounds(eachindex(B), I)
 end

--- a/src/BSplines/basis.jl
+++ b/src/BSplines/basis.jl
@@ -118,6 +118,48 @@ julia> B[6](-0.5, Derivative(1))
     BasisFunction(B, i, T)
 end
 
+"""
+    (B::AbstractBSplineBasis)(
+        x::Real, [op = Derivative(0)], [T = float(typeof(x))];
+        [ileft = nothing],
+    ) -> (i, bs)
+
+Evaluates all basis functions which are non-zero at `x`.
+
+See [`evaluate_all`](@ref) for details on optional arguments and on the returned values.
+
+# Examples
+
+```jldoctest
+julia> B = BSplineBasis(BSplineOrder(4), -1:0.1:1)
+23-element BSplineBasis of order 4, domain [-1.0, 1.0]
+ knots: [-1.0, -1.0, -1.0, -1.0, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4  …  0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0, 1.0]
+
+julia> i, bs = B(0.42)
+(18, (0.0013333333333333268, 0.28266666666666657, 0.6306666666666667, 0.08533333333333339))
+
+julia> sum(bs)
+1.0
+
+julia> bs[1] - B[i](0.42)
+0.0
+
+julia> bs[2] - B[i - 1](0.42)
+-5.551115123125783e-17
+
+julia> B(0.44; ileft = i)
+(18, (0.01066666666666666, 0.4146666666666667, 0.5386666666666665, 0.03599999999999999))
+
+julia> B(0.42, Float32)
+(18, (0.0013333336f0, 0.28266668f0, 0.6306667f0, 0.085333325f0))
+
+julia> B(0.42, Derivative(1))
+(18, (0.19999999999999937, 6.4, -3.3999999999999977, -3.200000000000001))
+```
+"""
+@inline (B::AbstractBSplineBasis)(args...; kws...) =
+    evaluate_all(B, args...; kws...)
+
 @inline function Base.checkbounds(B::AbstractBSplineBasis, I)
     checkbounds(eachindex(B), I)
 end

--- a/src/BSplines/evaluate_all.jl
+++ b/src/BSplines/evaluate_all.jl
@@ -123,7 +123,7 @@ function _evaluate_all(
             # This is the same as in de Boor's BSPLVB routine.
             # In particular, this allows plotting the extension of a polynomial
             # piece outside of its knot interval (as in de Boor's Fig. 6, p. 114).
-            bs_1 = one(T)
+            bs_1 = (one(T),)
         end
         for q ∈ 2:k
             bp = Symbol(:bs_, q - 1)

--- a/src/BSplines/evaluate_all.jl
+++ b/src/BSplines/evaluate_all.jl
@@ -21,10 +21,10 @@ More precisely:
 
 - `i` is the index of the first B-spline knot ``t_{i}`` when going from ``x``
   towards the left.
-  In other words, it is such that ``t_{i} ≤ x < t{i + 1}``.
+  In other words, it is such that ``t_{i} ≤ x < t_{i + 1}``.
 
   It is effectively computed as `i = searchsortedlast(knots(B), x)`.
-  If the right value of `i` is already known, one can avoid this computation by
+  If the correct value of `i` is already known, one can avoid this computation by
   manually passing this index via the optional `ileft` keyword argument.
 
 - `bs` is a tuple of B-splines evaluated at ``x``:
@@ -42,6 +42,10 @@ More precisely:
 One can pass the optional `op` argument to compute B-spline derivatives instead
 of the actual B-spline values.
 
+## Examples
+
+See [`AbstractBSplineBasis`](@ref) for some examples using the alternative
+evaluation syntax `B(x, [op], [T]; [ileft])`, which calls this function.
 """
 @propagate_inbounds function evaluate_all(
         B::BSplineBasis, x::Real, op::Derivative, ::Type{T}; kws...,

--- a/src/BSplines/evaluate_all.jl
+++ b/src/BSplines/evaluate_all.jl
@@ -6,14 +6,13 @@ using Base: @propagate_inbounds
 using StaticArrays: MVector
 
 # TODO
-# - derivatives
 # - define (::BSplineBasis)(x) as an alias for `evaluate_all`
 # - what about recombined bases?
 
 """
     evaluate_all(
         B::BSplineBasis, x::Real,
-        [D = Derivative(0)], [T = float(typeof(x))];
+        [op = Derivative(0)], [T = float(typeof(x))];
         [ileft = nothing],
     ) -> i, bs
 
@@ -44,21 +43,21 @@ More precisely:
 
 ## Computing derivatives
 
-One can pass the optional `D` argument to compute B-spline derivatives instead
+One can pass the optional `op` argument to compute B-spline derivatives instead
 of the actual B-spline values.
 
 """
 @propagate_inbounds function evaluate_all(
-        B::BSplineBasis, x::Real, D::Derivative, ::Type{T}; kws...,
-    ) where {T <: Real}
-    _evaluate_all(knots(B), x, BSplineOrder(order(B)), D, T; kws...)
+        B::BSplineBasis, x::Real, op::Derivative, ::Type{T}; kws...,
+    ) where {T <: Number}
+    _evaluate_all(knots(B), x, BSplineOrder(order(B)), op, T; kws...)
 end
 
 @propagate_inbounds evaluate_all(
-    B, x, D::AbstractDifferentialOp = Derivative(0); kws...,
-) = evaluate_all(B, x, D, float(typeof(x)); kws...)
+    B, x, op::AbstractDifferentialOp = Derivative(0); kws...,
+) = evaluate_all(B, x, op, float(typeof(x)); kws...)
 
-@propagate_inbounds evaluate_all(B, x, ::Type{T}; kws...) where {T <: Real} =
+@propagate_inbounds evaluate_all(B, x, ::Type{T}; kws...) where {T <: Number} =
     evaluate_all(B, x, Derivative(0), T; kws...)
 
 @propagate_inbounds function _knotdiff(x, ts, i, n)
@@ -109,7 +108,7 @@ end
 
 function _evaluate_all(
         ts::AbstractVector, x::Real, ::BSplineOrder{k},
-        D::Derivative{0}, ::Type{T};
+        op::Derivative{0}, ::Type{T};
         ileft = nothing,
     ) where {k, T}
     if @generated
@@ -144,14 +143,14 @@ function _evaluate_all(
             return i, $bk
         end
     else
-        _evaluate_all_alt(ts, x, BSplineOrder(k), D, T; ileft = ileft)
+        _evaluate_all_alt(ts, x, BSplineOrder(k), op, T; ileft = ileft)
     end
 end
 
 # Derivatives
 function _evaluate_all(
         ts::AbstractVector, x::Real, ::BSplineOrder{k},
-        D::Derivative{n}, ::Type{T};
+        op::Derivative{n}, ::Type{T};
         ileft = nothing,
     ) where {k, n, T}
     if @generated
@@ -181,7 +180,7 @@ function _evaluate_all(
             return i, $bk
         end
     else
-        _evaluate_all_alt(ts, x, BSplineOrder(k), D, T; ileft = ileft)
+        _evaluate_all_alt(ts, x, BSplineOrder(k), op, T; ileft = ileft)
     end
 end
 

--- a/src/BSplines/evaluate_all.jl
+++ b/src/BSplines/evaluate_all.jl
@@ -1,0 +1,117 @@
+# Functions for efficiently evaluating all non-zero B-splines (and/or their
+# derivatives) at a given point.
+
+using Base.Cartesian: @ntuple
+using Base: @propagate_inbounds
+
+# TODO
+# - what to do on the right boundary?
+#   * what happens when knots are not augmented??
+#   * what happens when x > xright? (extrapolation)
+# - add a non-generated variant (use `if @generated`)
+# - derivatives
+# - define (::BSplineBasis)(x) as an alias for `evaluate_all`
+# - what about recombined bases?
+
+"""
+    evaluate_all(
+        B::BSplineBasis, x::Real, [T = float(typeof(x))];
+        [ileft = nothing],
+    ) -> i, bs
+
+Evaluate all B-splines which are non-zero at coordinate `x`.
+
+Returns a tuple `(i, bs)`, where `i` is an index identifying the basis functions
+that were computed, and `bs` is a tuple with the actual values.
+
+More precisely:
+
+- `i` is the index of the first B-spline knot ``t_{i}`` when going from ``x``
+  towards the left.
+  In other words, it is such that ``t_{i} ≤ x < t{i + 1}``.
+
+  It is effectively computed as `i = searchsortedlast(knots(B), x)`.
+  If one already knows the right value of `i`, and wants to avoid this
+  computation, one can manually pass `i` via the optional `ileft` keyword
+  argument.
+
+- `bs` is a tuple of B-splines evaluated at ``x``:
+
+  ```math
+  (b_i(x), b_{i - 1}(x), …, b_{i - k + 1}(x)).
+  ```
+
+  It contains ``k`` values, where ``k`` is the order of the B-spline basis.
+  Note that values are returned in backwards order starting from the ``i``-th
+  B-spline.
+"""
+@propagate_inbounds function evaluate_all(
+        B::BSplineBasis, x::Real, ::Type{T}; kws...,
+    ) where {T}
+    _evaluate_all_gen(knots(B), x, BSplineOrder(order(B)), T; kws...)
+end
+
+@propagate_inbounds function _knotdiff(x, ts, i, n)
+    ti = ts[i]
+    tj = ts[i + n]
+    y = (x - ti) / (tj - ti)
+    # TODO
+    # - do I need this?
+    # - is this actually right?
+    # - what happens with knots with multiplicity > 1?
+    ifelse(x == ti == tj, one(y), y)  # avoid returning 0/0
+end
+
+@generated function _evaluate_all_gen(
+        ts::AbstractVector, x::Real, ::BSplineOrder{k}, ::Type{T};
+        ileft = nothing,
+    ) where {k, T}
+    @assert k ≥ 1
+    ex = quote
+        # TODO is this correct?
+        xleft = ts[begin + k - 1]
+        xright = ts[end - k + 1]
+        i = isnothing(ileft) ? searchsortedlast(ts, x) : ileft
+        if x < xleft || x > xright
+            return (i, @ntuple($k, j -> zero($T)))
+        end
+        bs_1 = if x == xright
+            i = lastindex(ts) - k
+            @inbounds (T(x == ts[i + 1]),)
+        else
+            @inbounds (T(ts[i] ≤ x < ts[i + 1]),)
+        end
+        @assert checkbounds(Bool, ts, (i - k + 1):(i + k))
+    end
+    for q ∈ 2:k
+        bp = Symbol(:bs_, q - 1)
+        bq = Symbol(:bs_, q)
+        ex_q = quote
+            Δs = @ntuple $(q - 1) j -> @inbounds(_knotdiff(x, ts, i - j + 1, $q - 1))
+            $bq = _evaluate_step(Δs, $bp, BSplineOrder($q), $T)
+        end
+        push!(ex.args, ex_q)
+    end
+    bk = Symbol(:bs_, k)
+    push!(ex.args, :( return i, $bk ))
+    ex
+end
+
+@generated function _evaluate_step(Δs, bp, ::BSplineOrder{k}, ::Type{T}) where {k, T}
+    bs = :(())
+    for j = 1:k
+        ex = quote
+            bj = zero($T)
+        end
+        if j ≠ 1
+            push!(ex.args, :( @inbounds bj += (1 - Δs[$j - 1]) * bp[$j - 1] ))
+        end
+        if j ≠ k
+            push!(ex.args, :( @inbounds bj += Δs[$j] * bp[$j] ))
+        end
+        push!(bs.args, ex)
+    end
+    bs
+end
+
+evaluate_all(B, x; kws...) = evaluate_all(B, x, float(typeof(x)); kws...)

--- a/src/BSplines/evaluate_all.jl
+++ b/src/BSplines/evaluate_all.jl
@@ -5,10 +5,6 @@ using Base.Cartesian: @ntuple
 using Base: @propagate_inbounds
 using StaticArrays: MVector
 
-# TODO
-# - define (::BSplineBasis)(x) as an alias for `evaluate_all`
-# - what about recombined bases?
-
 """
     evaluate_all(
         B::BSplineBasis, x::Real,

--- a/src/Galerkin/linear.jl
+++ b/src/Galerkin/linear.jl
@@ -203,8 +203,8 @@ function galerkin_matrix!(
 
     fill!(S, 0)
     nlast = last(eachindex(ts))
-    δ1 = first(num_constraints(B1))
-    δ2 = first(num_constraints(B2))
+    ioff = first(num_constraints(B1))
+    joff = first(num_constraints(B2))
 
     # We loop over all knot segments Ω[n] = (ts[n], ts[n + 1]).
     # We integrate all supported B-spline products B1[i] * B2[j] over this
@@ -221,10 +221,11 @@ function galerkin_matrix!(
         # @assert all(x -> tn ≤ x ≤ tn1, xs)
 
         for (x, w) ∈ zip(xs, quadw)
-            ilast = n - δ1
-            jlast = n - δ2
+            ilast = n - ioff
+            jlast = n - joff
             _, bis = evaluate_all(B1, x, deriv[1], T; ileft = ilast)
             _, bjs = same_ij ? (ilast, bis) : evaluate_all(B2, x, deriv[2], T; ileft = jlast)
+            y = metric.α * w
             for (δj, bj) ∈ pairs(bjs), (δi, bi) ∈ pairs(bis)
                 i = ilast + 1 - δi
                 j = jlast + 1 - δj
@@ -239,7 +240,7 @@ function galerkin_matrix!(
                     @assert iszero(bj)
                     continue
                 end
-                @inbounds A[i, j] += metric.α * w * bi * bj
+                @inbounds A[i, j] += y * bi * bj
             end
         end
     end

--- a/src/Galerkin/linear.jl
+++ b/src/Galerkin/linear.jl
@@ -224,7 +224,8 @@ function galerkin_matrix!(
             ilast = n - ioff
             jlast = n - joff
             _, bis = evaluate_all(B1, x, deriv[1], T; ileft = ilast)
-            _, bjs = same_ij ? (ilast, bis) : evaluate_all(B2, x, deriv[2], T; ileft = jlast)
+            _, bjs = same_ij ?
+                (ilast, bis) : evaluate_all(B2, x, deriv[2], T; ileft = jlast)
             y = metric.α * w
             for (δj, bj) ∈ pairs(bjs), (δi, bi) ∈ pairs(bis)
                 i = ilast + 1 - δi

--- a/src/Galerkin/quadratic.jl
+++ b/src/Galerkin/quadratic.jl
@@ -119,8 +119,9 @@ function galerkin_tensor!(
 
             # We compute the submatrix A[:, :, l] for each `l`.
             for (δl, bl) in pairs(bls)
-                y₀ = metric.α * w * bl
+                iszero(bl) && continue  # can prevent problems at the borders
                 l = l₀ + δl
+                y₀ = metric.α * w * bl
                 @inbounds fill!(Al, 0)
                 inds = BandedTensors.band_indices(A, l)
                 # @assert inds == (l - k + 1:l + k - 1) .+ bandshift(A)[3]

--- a/src/Galerkin/quadratic.jl
+++ b/src/Galerkin/quadratic.jl
@@ -27,7 +27,7 @@ function galerkin_tensor(
     if length(Bs[1]) != length(Bs[2])
         throw(DimensionMismatch("the first two bases must have the same lengths"))
     end
-    δl, δr = num_constraints(Bs[3]) .- num_constraints(Bs[1])
+    δl = first(num_constraints(Bs[3])) - first(num_constraints(Bs[1]))
     A = BandedTensor3D{T}(undef, dims, Val(b), bandshift=(0, 0, δl))
     galerkin_tensor!(A, Bs, deriv)
 end
@@ -63,6 +63,10 @@ function galerkin_tensor!(
     Ni, Nj, Nl = Ns
     @assert Ni == Nj  # verified at construction of BandedTensor3D
 
+    ioff = first(num_constraints(Bi))
+    joff = first(num_constraints(Bj))
+    loff = first(num_constraints(Bl))
+
     # Orders and knots are assumed to be the same (see _check_bases).
     k = order(Bi)
     ts = knots(Bi)
@@ -86,7 +90,7 @@ function galerkin_tensor!(
 
     fill!(A, 0)
     T = eltype(A)
-    Al = @MMatrix zeros(T, 2k - 1, 2k - 1)
+    Al = zero(MMatrix{2k - 1, 2k - 1, T})
     nlast = last(eachindex(ts))
 
     @inbounds for n in eachindex(ts)
@@ -97,30 +101,45 @@ function galerkin_tensor!(
         metric = QuadratureMetric(tn, tn1)
         xs = metric .* quadx
 
-        is = nonzero_in_segment(Bi, n)
-        js = nonzero_in_segment(Bj, n)
-        ls = nonzero_in_segment(Bl, n)
+        ilast = n - ioff
+        jlast = n - joff
+        llast = n - loff
+        l₀ = llast - order(Bs[3])
 
-        bis = eval_basis_functions(Bi, is, xs, deriv[1])
-        bjs = same_12 ?
-            bis : eval_basis_functions(Bj, js, xs, deriv[2])
-        bls = same_13 ?
-            bis : same_23 ?
-            bjs : eval_basis_functions(Bl, ls, xs, deriv[3])
+        for (x, w) ∈ zip(xs, quadw)
+            _, bis = evaluate_all(Bi, x, deriv[1], T; ileft = ilast)
+            _, bjs = same_12 ?
+                (ilast, bis) : evaluate_all(Bj, x, deriv[2], T; ileft = jlast)
+            _, bls = same_13 ?
+                (ilast, bis) : same_23 ?
+                (jlast, bjs) : evaluate_all(Bl, x, deriv[3], T; ileft = llast)
 
-        # We compute the submatrix A[:, :, l] for each `l`.
-        for (nl, l) in enumerate(ls)
-            fill!(Al, 0)
-            inds = BandedTensors.band_indices(A, l)
-            # @assert is ⊆ inds && js ⊆ inds
-            # @assert size(Al, 1) == size(Al, 2) == length(inds)
-            δi = searchsortedlast(inds, is[1]) - 1
-            δj = searchsortedlast(inds, js[1]) - 1
-            for nj in eachindex(js), ni in eachindex(is)
-                Al[ni + δi, nj + δj] =
-                    metric.α * ((bis[ni] .* bjs[nj] .* bls[nl]) ⋅ quadw)
+            # Iterate in increasing order (not sure if it really helps performance)
+            bls = reverse(bls)
+
+            # We compute the submatrix A[:, :, l] for each `l`.
+            for (δl, bl) in pairs(bls)
+                y₀ = metric.α * w * bl
+                l = l₀ + δl
+                @inbounds fill!(Al, 0)
+                inds = BandedTensors.band_indices(A, l)
+                # @assert inds == (l - k + 1:l + k - 1) .+ bandshift(A)[3]
+                # @assert (ilast - k + 1:ilast) ⊆ inds
+                # @assert (jlast - k + 1:jlast) ⊆ inds
+                Δi = first(inds) - 1
+                Δj = Δi
+                for (δj, bj) ∈ pairs(bjs)
+                    y₁ = y₀ * bj
+                    j = jlast + 1 - δj
+                    jj = j - Δj
+                    for (δi, bi) ∈ pairs(bis)
+                        i = ilast + 1 - δi  # actual index of basis function
+                        ii = i - Δi         # index in submatrix Al
+                        @inbounds Al[ii, jj] = y₁ * bi
+                    end
+                end
+                @inbounds A[:, :, l] += Al
             end
-            A[:, :, l] += Al
         end
     end
 

--- a/src/Galerkin/quadratures.jl
+++ b/src/Galerkin/quadratures.jl
@@ -57,24 +57,3 @@ end
 # Apply metric to normalised coordinate (x ∈ [-1, 1]).
 Base.:*(M::QuadratureMetric, x::Real) = M.α * x + M.β
 Broadcast.broadcastable(M::QuadratureMetric) = Ref(M)
-
-# Evaluate elements of basis `B` (given by indices `is`) at points `xs`.
-# The length of `xs` is assumed static.
-# The length of `is` is generally equal to the B-spline order, but may me
-# smaller near the boundaries (this is not significant if knots are "augmented",
-# as is the default).
-# TODO implement evaluation of all B-splines at once (should be much faster...)
-function eval_basis_functions(B, is, xs, args...)
-    k = order(B)
-    @assert length(is) ≤ k
-    ntuple(Val(k)) do n
-        # In general, `is` will have length equal `k`.
-        # If its length is less than `k` (may happen near boundaries, if knots
-        # are not "augmented"), we repeat values for the first B-spline, just
-        # for type stability concerns. These values are never used.
-        i = n > length(is) ? is[1] : is[n]
-        map(xs) do x
-            B[i](x, args...)
-        end
-    end
-end

--- a/src/Recombinations/bases.jl
+++ b/src/Recombinations/bases.jl
@@ -369,3 +369,39 @@ end
 
     ϕ::T
 end
+
+@propagate_inbounds function BSplines.evaluate_all(
+        R::RecombinedBSplineBasis, x::Real, args...;
+        ileft::Union{Int, Nothing} = nothing, kws...,
+    )
+    B = parent(R)
+    k = order(B)
+    off = num_constraints(R)[1]
+    if !isnothing(ileft)
+        ileft += off
+    end
+    ilast, bs = evaluate_all(B, x, args...; ileft, kws...)
+    jlast = ilast - off
+    A = recombination_matrix(R)
+    N = length(R)
+
+    ϕs = zero(MVector{k, eltype(bs)})
+    for δj = 1:k
+        j = jlast + 1 - δj  # recombined index ϕ_j
+        1 ≤ j ≤ N || continue
+        block = which_recombine_block(A, j)
+        if block == 2
+            @inbounds ϕs[δj] = bs[δj]  # no recombination needed (most common case)
+        else
+            is = nzrows(A, j; block)
+            for i ∈ is
+                δi = ilast + 1 - i
+                # @boundscheck checkbounds(Bool, eachindex(bs), δi)
+                @inbounds ϕs[δj] += getindex(A, i, j; block) * bs[δi]
+            end
+        end
+    end
+
+    # We return the index of the last recombined basis function ϕ_j.
+    jlast, Tuple(ϕs)
+end

--- a/src/SplineApproximations/SplineApproximations.jl
+++ b/src/SplineApproximations/SplineApproximations.jl
@@ -83,7 +83,7 @@ SplineApproximation containing the 7-element Spline{Float64}:
  basis: 7-element BSplineBasis of order 3, domain [-1.0, 1.0]
  order: 3
  knots: [-1.0, -1.0, -1.0, -0.6, -0.2, 0.2, 0.6, 1.0, 1.0, 1.0]
- coefficients: [-0.841471, -0.731727, -0.39727, 0.0, 0.39727, 0.731727, 0.841471]
+ coefficients: [-0.841471, -0.731727, -0.39727, 2.85767e-17, 0.39727, 0.731727, 0.841471]
  approximation method: interpolation at [-1.0, -0.8, -0.4, 0.0, 0.4, 0.8, 1.0]
 
 julia> sin(0.3), S_interp(0.3)
@@ -98,7 +98,7 @@ SplineApproximation containing the 7-element Spline{Float64}:
  approximation method: interpolation at [-1.0, -0.8, -0.4, 0.0, 0.4, 0.8, 1.0]
 
 julia> exp(0.3), S_interp(0.3)
-(1.3498588075760032, 1.3491015490105398)
+(1.3498588075760032, 1.3491015490105396)
 
 julia> S_fast = approximate(exp, B, VariationDiminishing())
 SplineApproximation containing the 7-element Spline{Float64}:
@@ -117,7 +117,7 @@ SplineApproximation containing the 7-element Spline{Float64}:
  approximation method: MinimiseL2Error()
 
 julia> x = 0.34; exp(x), S_opt(x), S_interp(x), S_fast(x)
-(1.4049475905635938, 1.4044530324752085, 1.4044149581073815, 1.4328668494041878)
+(1.4049475905635938, 1.4044530324752076, 1.4044149581073813, 1.4328668494041878)
 ```
 """
 approximate(f, B::AbstractBSplineBasis) =

--- a/src/SplineInterpolations/SplineInterpolations.jl
+++ b/src/SplineInterpolations/SplineInterpolations.jl
@@ -158,7 +158,7 @@ julia> (Derivative(1) * itp)(-1)
 -0.01663433622896893
 
 julia> (Derivative(2) * itp)(-1)
-10.527273287554962
+10.52727328755495
 
 julia> Snat = interpolate(xs, ys, BSplineOrder(4), Natural())
 SplineInterpolation containing the 21-element Spline{Float64}:

--- a/src/Splines/spline.jl
+++ b/src/Splines/spline.jl
@@ -204,6 +204,9 @@ julia> S = Spline(B, rand(length(B)))
  knots: [-1.0, -1.0, -1.0, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.0, 1.0, 1.0]
  coefficients: [0.461501, 0.619799, 0.654451, 0.667213, 0.334672, 0.618022, 0.967496, 0.900014, 0.611195, 0.469467, 0.221618, 0.80084, 0.269533]
 
+julia> Derivative(0) * S === S
+true
+
 julia> Derivative(1) * S
 12-element Spline{Float64}:
  basis: 12-element BSplineBasis of order 3, domain [-1.0, 1.0]
@@ -231,6 +234,8 @@ Returns `N`-th derivative of spline `S` as a new spline.
 Base.diff(S::Spline, op = Derivative(1)) = op * S
 
 _diff(::AbstractBSplineBasis, S, etc...) = diff(parent_spline(S), etc...)
+
+_diff(::BSplineBasis, S::Spline, ::Derivative{0}) = S
 
 function _diff(
         ::BSplineBasis, S::Spline, ::Derivative{Ndiff} = Derivative(1),

--- a/test/airy.jl
+++ b/test/airy.jl
@@ -37,7 +37,7 @@ function test_airy_equation()
         Tc = @inferred galerkin_tensor((R, R, B), Derivative.((0, 0, 0)))
         Mc = @inferred Tc * cs
         @test Mc isa BandedMatrix
-        @test issymmetric(Mc)
+        @test Mc ≈ Mc'  # the matrix is practically symmetric
         Hermitian(Mc)
     end
 

--- a/test/bsplines.jl
+++ b/test/bsplines.jl
@@ -48,6 +48,8 @@ function test_bsplines(ord::BSplineOrder)
         # Test reusing knot interval (ileft)
         @test (i, bs) == @inferred evaluate_all(B, x; ileft = i)
 
+        @test sum(bs) ≈ 1  # partition of unity property
+
         # 1. Compare with evaluation of single B-spline
         for j ∈ eachindex(bs)
             @test bs[j] ≈ B[i - j + 1](x)

--- a/test/bsplines.jl
+++ b/test/bsplines.jl
@@ -44,6 +44,14 @@ function test_bsplines(ord::BSplineOrder)
     @testset "Evaluate" for x ∈ xs_eval
         i, bs = @inferred evaluate_all(B, x)
         @test length(bs) == k
+        @test eltype(bs) === Float64
+
+        let
+            i′, bs′ = @inferred evaluate_all(B, x, Float32)
+            @test eltype(bs′) === Float32
+            @test i === i′
+            @test all(bs .≈ bs′)
+        end
 
         # Test reusing knot interval (ileft)
         @test (i, bs) == @inferred evaluate_all(B, x; ileft = i)
@@ -62,7 +70,10 @@ function test_bsplines(ord::BSplineOrder)
         # 3. Compare to non-generated version (assuming the @generated version
         #    is called)
         @test evaluate_all(B, x) == @inferred BSplines._evaluate_all_alt(
-            knots(B), x, BSplineOrder(k), eltype(bs),
+            knots(B), x, BSplineOrder(k), Derivative(0), eltype(bs),
+        )
+        @test evaluate_all(B, x, Float32) == @inferred BSplines._evaluate_all_alt(
+            knots(B), x, BSplineOrder(k), Derivative(0), Float32,
         )
     end
 

--- a/test/bsplines.jl
+++ b/test/bsplines.jl
@@ -56,6 +56,12 @@ function test_bsplines(ord::BSplineOrder)
         # 2. Compare with full evaluation of a spline
         cs = view(coefficients(S), i:-1:(i - k + 1))
         @test S(x) ≈ dot(cs, bs)
+
+        # 3. Compare to non-generated version (assuming the @generated version
+        #    is called)
+        @test evaluate_all(B, x) == @inferred BSplines._evaluate_all_alt(
+            knots(B), x, BSplineOrder(k), eltype(bs),
+        )
     end
 
     nothing

--- a/test/bsplines.jl
+++ b/test/bsplines.jl
@@ -1,0 +1,55 @@
+using Test
+using BSplineKit
+using Random
+
+using BSplineKit.BSplines:
+    find_knot_interval
+
+function test_bsplines(ord::BSplineOrder)
+    rng = MersenneTwister(42)
+    ξs = sort!(rand(rng, 20))
+    ξs[begin] = 0; ξs[end] = 1;
+    B = BSplineBasis(ord, copy(ξs))
+    N = length(B)
+    ts = knots(B)
+    a = first(ts)
+    b = last(ts)
+    @test (a, b) == boundaries(B)
+    k = order(B)
+
+    @testset "Find interval" begin
+        @inferred find_knot_interval(ts, 0.3)
+        @test find_knot_interval(ts, a - 1) == (1, -1)
+        @test find_knot_interval(ts, a) == (k, 0)
+        @test find_knot_interval(ts, b) == (N, 0)
+        @test find_knot_interval(ts, b + 1) == (N, 1)
+        let x = (a + b) / 3  # test on a "normal" location
+            @test find_knot_interval(ts, x) == (searchsortedlast(ts, x), 0)
+        end
+        let i = length(ts) ÷ 2  # test on a knot location
+            @test find_knot_interval(ts, ts[i]) == (i, 0)
+        end
+    end
+
+    xs_eval = [
+        ts[begin],                                          # at left boundary
+        ts[begin + k + 2],                                  # on a knot
+        0.2 * ts[begin + k + 2] + 0.8 * ts[begin + k + 3],  # between two knots
+        ts[end],                                            # at right boundary
+    ]
+
+    @testset "Evaluate" for x ∈ xs_eval
+        # We evaluate B-splines using two independent functions and compare the
+        # results.
+        i, bs = @inferred evaluate_all(B, x)
+        for j ∈ eachindex(bs)
+            @test bs[j] ≈ B[i - j + 1](x)
+        end
+    end
+
+    nothing
+end
+
+@testset "B-splines (k = $k)" for k ∈ (2, 4, 5, 6, 8)
+    test_bsplines(BSplineOrder(k))
+end

--- a/test/bsplines.jl
+++ b/test/bsplines.jl
@@ -39,41 +39,56 @@ function test_bsplines(ord::BSplineOrder)
         ts[end],                                            # at right boundary
     ]
 
+    derivs = Derivative.((0, 1, 2))
+    _order(::Derivative{n}) where {n} = n
+
     S = Spline(B, randn(rng, length(B)))
 
-    @testset "Evaluate" for x ∈ xs_eval
-        i, bs = @inferred evaluate_all(B, x)
+    @testset "Evaluate $op | x = $x" for x ∈ xs_eval, op ∈ derivs
+        i, bs = @inferred evaluate_all(B, x, op)
         @test length(bs) == k
         @test eltype(bs) === Float64
 
         let
-            i′, bs′ = @inferred evaluate_all(B, x, Float32)
+            i′, bs′ = @inferred evaluate_all(B, x, op, Float32)
             @test eltype(bs′) === Float32
             @test i === i′
             @test all(bs .≈ bs′)
         end
 
         # Test reusing knot interval (ileft)
-        @test (i, bs) == @inferred evaluate_all(B, x; ileft = i)
+        @test (i, bs) == @inferred evaluate_all(B, x, op; ileft = i)
 
-        @test sum(bs) ≈ 1  # partition of unity property
+        if op === Derivative(0)
+            @test sum(bs) ≈ 1  # partition of unity property
+        else
+            @test abs(sum(bs)) < 10eps(maximum(bs))  # ≈ 0
+        end
+
+        nderiv = _order(op)
 
         # 1. Compare with evaluation of single B-spline
-        for j ∈ eachindex(bs)
-            @test bs[j] ≈ B[i - j + 1](x)
+        if nderiv < k
+            for j ∈ eachindex(bs)
+                @test bs[j] ≈ B[i - j + 1](x, op)
+            end
         end
 
         # 2. Compare with full evaluation of a spline
-        cs = view(coefficients(S), i:-1:(i - k + 1))
-        @test S(x) ≈ dot(cs, bs)
+        if nderiv < k
+            S′ = op * S  # this is exactly `S` if op == Derivative(0)
+            cs = view(coefficients(S), i:-1:(i - k + 1))
+            @test S′(x) ≈ dot(cs, bs)
+        end
 
         # 3. Compare to non-generated version (assuming the @generated version
         #    is called)
-        @test evaluate_all(B, x) == @inferred BSplines._evaluate_all_alt(
-            knots(B), x, BSplineOrder(k), Derivative(0), eltype(bs),
+        @test evaluate_all(B, x, op) == @inferred BSplines._evaluate_all_alt(
+            knots(B), x, BSplineOrder(k), op, eltype(bs),
         )
-        @test evaluate_all(B, x, Float32) == @inferred BSplines._evaluate_all_alt(
-            knots(B), x, BSplineOrder(k), Derivative(0), Float32,
+
+        @test evaluate_all(B, x, op, Float32) == @inferred BSplines._evaluate_all_alt(
+            knots(B), x, BSplineOrder(k), op, Float32,
         )
     end
 

--- a/test/bsplines.jl
+++ b/test/bsplines.jl
@@ -1,6 +1,7 @@
 using Test
 using BSplineKit
 using Random
+using LinearAlgebra: dot
 
 using BSplineKit.BSplines:
     find_knot_interval
@@ -38,13 +39,22 @@ function test_bsplines(ord::BSplineOrder)
         ts[end],                                            # at right boundary
     ]
 
+    S = Spline(B, randn(rng, length(B)))
+
     @testset "Evaluate" for x ∈ xs_eval
-        # We evaluate B-splines using two independent functions and compare the
+        # We evaluate B-splines using three independent methods and compare the
         # results.
         i, bs = @inferred evaluate_all(B, x)
+        @test length(bs) == k
+
+        # 1. Compare with evaluation of single B-spline
         for j ∈ eachindex(bs)
             @test bs[j] ≈ B[i - j + 1](x)
         end
+
+        # 2. Compare with full evaluation of a spline
+        cs = view(coefficients(S), i:-1:(i - k + 1))
+        @test S(x) ≈ dot(cs, bs)
     end
 
     nothing

--- a/test/bsplines.jl
+++ b/test/bsplines.jl
@@ -44,6 +44,10 @@ function test_bsplines(ord::BSplineOrder)
 
     S = Spline(B, randn(rng, length(B)))
 
+    let x = 0.3
+        @test evaluate_all(B, x) == @inferred B(x)  # alias for `evaluate_all`
+    end
+
     @testset "Evaluate $op | x = $x" for x ∈ xs_eval, op ∈ derivs
         i, bs = @inferred evaluate_all(B, x, op)
         @test length(bs) == k

--- a/test/bsplines.jl
+++ b/test/bsplines.jl
@@ -135,7 +135,9 @@ rng = MersenneTwister(42)
 
 @testset "B-splines (k = $k)" for k ∈ (2, 4, 5, 6, 8)
     B = BSplineBasis(BSplineOrder(k), copy(ξs))
-    @testset "B-spline basis" test_bsplines(B)
+    @testset "B-spline basis" begin
+        test_bsplines(B)
+    end
     ops = (Derivative(0), Derivative(1), Natural())
     @testset "Recombined (op = $op)" for op ∈ ops
         op == Natural() && isodd(k) && continue

--- a/test/bsplines.jl
+++ b/test/bsplines.jl
@@ -42,10 +42,11 @@ function test_bsplines(ord::BSplineOrder)
     S = Spline(B, randn(rng, length(B)))
 
     @testset "Evaluate" for x ∈ xs_eval
-        # We evaluate B-splines using three independent methods and compare the
-        # results.
         i, bs = @inferred evaluate_all(B, x)
         @test length(bs) == k
+
+        # Test reusing knot interval (ileft)
+        @test (i, bs) == @inferred evaluate_all(B, x; ileft = i)
 
         # 1. Compare with evaluation of single B-spline
         for j ∈ eachindex(bs)

--- a/test/galerkin.jl
+++ b/test/galerkin.jl
@@ -184,7 +184,7 @@ function test_galerkin_recombined()
             @testset "3D tensor" begin
                 test_galerkin_tensor(R)
             end
-            @test M == galerkin_matrix((B, R))'
+            @test M ≈ galerkin_matrix((B, R))'
             let (δl, δr) = num_constraints(R)
                 n, m = size(M)
                 @test n + δl + δr == m
@@ -196,7 +196,7 @@ function test_galerkin_recombined()
                 # basis.
                 M_base = galerkin_matrix(B)
                 I = (δl + r + 1):(m - (δr + r))
-                @test view(M, (r + 1):(n - r), I) == view(M_base, I, I)
+                @test view(M, (r + 1):(n - r), I) ≈ view(M_base, I, I)
             end
         end
     end

--- a/test/galerkin.jl
+++ b/test/galerkin.jl
@@ -171,7 +171,7 @@ function test_galerkin_recombined()
                     T″ = galerkin_tensor(R, Derivative.((0, 0, 2)))
                     T1 = galerkin_tensor(R, Derivative.((1, 0, 1)))
                     T2 = galerkin_tensor(R, Derivative.((0, 1, 1)))
-                    @test T2 == permutedims(T1, (2, 1, 3))
+                    @test T2 ≈ permutedims(T1, (2, 1, 3))
                     @test norm(T″ + T1 + T2, Inf) < norm(T1, Inf) * ε
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ gauss_lobatto_points(N) = [-cos(π * n / N) for n = 0:N]
 
 include("diffops.jl")
 include("knots.jl")
+include("bsplines.jl")
 include("splines.jl")
 include("natural.jl")
 include("interpolation.jl")


### PR DESCRIPTION
This PR provides the `evaluate_all` function, which evaluates, at a given point `x`, all B-splines which are non-zero at that point. The function also works for recombined B-splines and for B-spline derivatives. This is much more efficient than evaluating B-splines one by one.

This new function is now used to construct collocation matrices (used in particular for interpolations) and Galerkin tensors.

For convenience, one can also evaluate a B-spline basis `B` using the `B(x)` syntax, which is equivalent to `evaluate_all`.

```julia
using BSplineKit
using BenchmarkTools
using Random

# Construct B-spline basis
rng = MersenneTwister(42)
ξs = sort!(rand(rng, 20))
ξs[begin] = 0; ξs[end] = 1;
B = BSplineBasis(BSplineOrder(6), copy(ξs))

# Evaluate non-zero B-splines at a point
# Note that the number of non-zero B-splines is equal to the B-spline order (k = 6 here)
x = 0.43
evaluate_all(B, x)
# = (14, (2.30799526056475e-6, 0.02175822604119263, 0.2704859488098379, 0.5541008832923826, 0.15224719511338874, 0.0014054387479374313))
```

The first returned element (here `i = 14`) is the index of the *last* B-spline that is non-zero at x.
The second element is a tuple `(b_{i}, b_{i - 1}, …, b{i - k + 1})` with the actual B-spline values.
Note that the values are returned in backwards order!

This syntax is exactly equivalent:

```julia
julia> B(x)
(14, (2.30799526056475e-6, 0.02175822604119263, 0.2704859488098379, 0.5541008832923826, 0.15224719511338874, 0.0014054387479374313))
```

To evaluate derivatives (e.g. the second derivative):

```julia
julia> evaluate_all(B, x, Derivative(2))
(14, (0.9303769749908197, 196.3554353920673, 101.55718315717507, -706.6327432445232, 359.10806040145405, 48.68168731883596))

julia> B(x, Derivative(2))
(14, (0.9303769749908197, 196.3554353920673, 101.55718315717507, -706.6327432445232, 359.10806040145405, 48.68168731883596))
```

One can also use recombined bases:
```julia
julia> R = RecombinedBSplineBasis(Natural(), B)
20-element RecombinedBSplineBasis of order 6, domain [0.0, 1.0]
 knots: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.160006, 0.172933, 0.176909, 0.262809  …  0.745181, 0.937466, 0.956916, 0.958926, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
 BCs left:  (D{2}, D{3})
 BCs right: (D{2}, D{3})

julia> R(x)
(12, (2.30799526056475e-6, 0.02175822604119263, 0.2704859488098379, 0.5541008832923826, 0.15224719511338874, 0.0014054387479374313))
```

Some benchmarks (before/after comparison):

```julia
julia> xs = collocation_points(B);

julia> C = collocation_matrix(B, xs);

julia> @btime collocation_matrix!($C, $B, $xs);
  18.274 μs (0 allocations: 0 bytes)  # before
  1.927 μs (0 allocations: 0 bytes)   # with this PR

julia> G = galerkin_matrix(B);

julia> @btime galerkin_matrix!($G, $B);
  68.334 μs (0 allocations: 0 bytes)  # before
  13.544 μs (0 allocations: 0 bytes)  # with this PR

julia> T = galerkin_tensor(B, Derivative.((0, 0, 1)));

julia> @btime galerkin_tensor!($T, $(B, B, B), Derivative.((0, 0, 1)));
  225.285 μs (272 allocations: 9.73 KiB)  # before
  109.311 μs (1 allocation: 1008 bytes)   # with this PR
```