### PR TITLE
Make sure spline evaluation is type stable

### DIFF
--- a/src/Splines/spline.jl
+++ b/src/Splines/spline.jl
@@ -149,6 +149,7 @@ function spline_kernel(
     ) where {T,k}
     # Algorithm adapted from https://en.wikipedia.org/wiki/De_Boor's_algorithm
     if @generated
+        d_k = Symbol(:d_, k)
         quote
             w_0 = zero(T)  # this is to make the compiler happy with w_{j - 1}
             @nexprs $k j -> d_j = @inbounds c[j + n - $k]
@@ -159,13 +160,13 @@ function spline_kernel(
                     j -> d_j = if j ≥ r
                         α = @inbounds (x - t[j + n - k]) /
                                       (t[j + n - r + 1] - t[j + n - k])
-                        (1 - α) * w_{j - 1} + α * w_{j}
+                        T((1 - α) * w_{j - 1} + α * w_{j})
                     else
                         w_j
                     end
                 )
             end
-            @nexprs 1 j -> d_{$k}  # return d_k
+            return $d_k
         end
     else
         # Similar using tuples (slower than @generated version).

--- a/test/splines.jl
+++ b/test/splines.jl
@@ -239,6 +239,15 @@ function test_splines(::BSplineOrder{k}) where {k}
         @inferred (() -> BSplineBasis(k, copy(x)))()
         g = BSplineBasis(k, copy(x))
 
+        @testset "Type stability" begin
+            # The return type of evaluating a spline should be the element type
+            # of the coefficient vector.
+            coefs = randn(Float32, length(g))
+            S = @inferred Spline(g, coefs)
+            xeval = Float64(0.32)
+            @test @inferred(S(xeval)) isa Float32
+        end
+
         @testset "BSplineBasis equality" begin
             h = BSplineBasis(k, copy(x))
             @test g == h


### PR DESCRIPTION
This fixes type stability of spline evaluation when working with Float32 (see new tests).