### PR TITLE
Small improvements to spline evaluations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSplineKit"
 uuid = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com>"]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"


### PR DESCRIPTION
The non-@generated variant of the spline evaluation kernel (which is never used in practice...) is now
faster than before. The @generated version (which is always used in practice) is still a bit faster, and has been slightly improved.


```julia
julia> B = BSplineBasis(BSplineOrder(4), -1:0.1:1)
23-element BSplineBasis of order 4, domain [-1.0, 1.0]
 knots: [-1.0, -1.0, -1.0, -1.0, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4  …  0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0, 1.0]

julia> S = Spline(B, randn(length(B)))
23-element Spline{Float64}:
 basis: 23-element BSplineBasis of order 4, domain [-1.0, 1.0]
 order: 4
 knots: [-1.0, -1.0, -1.0, -1.0, -0.9, -0.8, -0.7, -0.6, -0.5, -0.4  …  0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0, 1.0]
 coefficients: [-0.887442, 0.386918, 1.79668, -0.384188, 2.06894, -1.29637, -0.365072, -0.772511, 1.31326, 0.70135  …  -1.5295, -0.34377, -0.0797124, -0.963989, 0.479627, -0.550763, -0.467999, -1.10901, 1.60983, 0.761048]

julia> x = 0.32
0.32

julia> @btime $S($x)
  123.635 ns (0 allocations: 0 bytes)  # non-@generated before

julia> @btime $S($x)
  77.163 ns (0 allocations: 0 bytes)   # non-@generated now

julia> @btime $S($x)
  68.862 ns (0 allocations: 0 bytes)  # @generated before

julia> @btime $S($x)
  61.757 ns (0 allocations: 0 bytes)  # @generated now
```