### PR TITLE
Allow evaluating individual periodic B-splines

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSplineKit"
 uuid = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com>"]
-version = "0.12.3"
+version = "0.12.4"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/BSplines/basis.jl
+++ b/src/BSplines/basis.jl
@@ -130,9 +130,11 @@ julia> B[6](-0.5, Derivative(1))
     BasisFunction(B, i, T)
 end
 
-@inline function Base.checkbounds(B::AbstractBSplineBasis, I)
-    checkbounds(eachindex(B), I)
-end
+@inline Base.checkbounds(::Type{Bool}, B::AbstractBSplineBasis, I) =
+    checkbounds(Bool, eachindex(B), I)
+
+@inline Base.checkbounds(B::AbstractBSplineBasis, I) =
+    checkbounds(Bool, B, I) || throw(BoundsError(B, I))
 
 @inline Base.eachindex(B::AbstractBSplineBasis) = Base.OneTo(length(B))
 

--- a/src/BSplines/periodic.jl
+++ b/src/BSplines/periodic.jl
@@ -231,6 +231,8 @@ Base.:(==)(A::PeriodicBSplineBasis, B::PeriodicBSplineBasis) =
     _evaluate_all(knots(B), x, BSplineOrder(order(B)), op, T; kws...)
 end
 
+support(B::PeriodicBSplineBasis, i::Integer) = i:(i + order(B))
+
 @inline function basis_to_array_index(::PeriodicBSplineBasis, axs, i::Int)
     while i < first(axs)
         i += length(axs)

--- a/src/BSplines/periodic.jl
+++ b/src/BSplines/periodic.jl
@@ -233,6 +233,11 @@ end
 
 support(B::PeriodicBSplineBasis, i::Integer) = i:(i + order(B))
 
+## Evaluation of individual B-splines.
+
+Base.checkbounds(::Type{Bool}, B::PeriodicBSplineBasis, I) = true  # accept all indices
+evaluate(B::PeriodicBSplineBasis, args...) = _evaluate(B, args...)
+
 @inline function basis_to_array_index(::PeriodicBSplineBasis, axs, i::Int)
     while i < first(axs)
         i += length(axs)

--- a/src/Recombinations/bases.jl
+++ b/src/Recombinations/bases.jl
@@ -343,7 +343,7 @@ function nonzero_in_segment(R::RecombinedBSplineBasis, n)
     nonzero_in_segment(parent(R), n - δl; N = length(R))
 end
 
-function support(R::RecombinedBSplineBasis, j)
+function support(R::RecombinedBSplineBasis, j::Integer)
     δl = num_constraints(R)[1]
     support(parent(R), j + δl)
 end

--- a/test/periodic.jl
+++ b/test/periodic.jl
@@ -58,6 +58,12 @@ function test_periodic_splines(ord::BSplineOrder)
 
         iall = ilast:-1:(ilast - k + 1)  # indices of all non-zero B-splines at x
 
+        @testset "Evaluate single" for (b, i) ∈ zip(bs, iall)
+            @test B[i](x) ≈ b
+            @test B[i - N](x - L) ≈ b  # periodicity
+            @test B[i + N](x + L) ≈ b  # periodicity
+        end
+
         @testset "Support" for i ∈ eachindex(B)
             sup = support(B, i)
             ta, tb = ts[sup[begin]], ts[sup[end]]

--- a/test/periodic.jl
+++ b/test/periodic.jl
@@ -56,6 +56,14 @@ function test_periodic_splines(ord::BSplineOrder)
         @test all(>(0), bs)
         @test sum(bs) ≈ 1  # partition of unity
 
+        iall = ilast:-1:(ilast - k + 1)  # indices of all non-zero B-splines at x
+
+        @testset "Support" for i ∈ eachindex(B)
+            sup = support(B, i)
+            ta, tb = ts[sup[begin]], ts[sup[end]]
+            @test (i ∈ iall) == (ta ≤ x < tb)
+        end
+
         # Check for zero allocations
         eval_alloc(B, x) = (B(x); @allocated(B(x)))
         @test 0 == eval_alloc(B, x)


### PR DESCRIPTION
This allows evaluating individual periodic B-splines using the `B[i](x)` syntax.