### PR TITLE
Periodic bases: require endpoint in knots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSplineKit"
 uuid = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com>"]
-version = "0.12.4"
+version = "0.13.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/Collocation/points.jl
+++ b/src/Collocation/points.jl
@@ -171,7 +171,7 @@ collocation_points(B::AbstractBSplineBasis; method = default_method(B)) =
 # usually the set of knots that the user passed when creating the basis.
 _knots_in_domain(B::AbstractBSplineBasis) = _knots_in_domain(knots(B))
 _knots_in_domain(ts::AbstractVector) = ts
-_knots_in_domain(ts::PeriodicKnots) = parent(ts)
+_knots_in_domain(ts::PeriodicKnots) = knots_in_main_period(ts)
 
 function collocation_points(B::AbstractBSplineBasis, method::SelectionMethod)
     x = similar(knots(B), length(B))

--- a/test/periodic.jl
+++ b/test/periodic.jl
@@ -6,14 +6,27 @@ using Test
 function test_periodic_splines(ord::BSplineOrder)
     k = order(ord)
     L = 1  # period
-    breaks = range(0, L; step = 0.05)[begin:end-1]
-    B = @inferred PeriodicBSplineBasis(ord, breaks, L)
+    breaks = range(0, L; step=0.05)
+    B = @inferred PeriodicBSplineBasis(ord, breaks)
+
+    # Test deprecated constructors
+    @testset "Deprecated" begin
+        @test_logs(
+            (:warn, r"The constructor PeriodicKnots\(.*\) is deprecated"),
+            BSplineKit.PeriodicKnots(breaks[1:end-1], L, ord),
+        )
+        @test_throws ArgumentError BSplineKit.PeriodicKnots(breaks, L, ord)
+        @test B == @test_deprecated PeriodicBSplineBasis(ord, breaks[begin:end-1], L)
+    end
+
     N = length(B)
 
     ts = @inferred knots(B)
     @test length(ts) == N + k  # consistency with the regular BSplineBasis
 
-    @test N == length(breaks)
+    @test N == length(breaks) - 1  # endpoint not included in `N`
+    @test N == length(parent(ts)) - 1
+    @test N + k == length(ts)
     @test @inferred(period(B)) == L
     @test typeof(period(B)) === eltype(breaks)
     @test @inferred(boundaries(B)) == (0, 1)
@@ -27,13 +40,10 @@ function test_periodic_splines(ord::BSplineOrder)
         "$N-element PeriodicBSplineBasis of order $k, domain [0.0, 1.0), period 1.0"
     )
 
-    # The last knot must be strictly less than `first(breaks) + period`
-    @test_throws ArgumentError PeriodicBSplineBasis(ord, breaks, last(breaks))
-
     # Order must be ≥ 1
-    @test_throws ArgumentError PeriodicBSplineBasis(BSplineOrder(0), breaks, L)
+    @test_throws ArgumentError PeriodicBSplineBasis(BSplineOrder(0), breaks)
 
-    @test PeriodicBSplineBasis(k, breaks, L) == B
+    @test PeriodicBSplineBasis(k, breaks) == B
 
     rng = MersenneTwister(42)
     S = @inferred Spline(B, randn(rng, length(B)))
@@ -52,16 +62,16 @@ function test_periodic_splines(ord::BSplineOrder)
 
     @testset "Evaluate x = $x" for x ∈ (0.02, 0.42, 0.89)
         ilast, bs = @inferred B(x)
-        @test (ilast, bs) == @inferred B(x; ileft = ilast)
+        @test (ilast, bs) == @inferred B(x; ileft=ilast)
         @test all(>(0), bs)
         @test sum(bs) ≈ 1  # partition of unity
 
-        iall = ilast:-1:(ilast - k + 1)  # indices of all non-zero B-splines at x
+        iall = ilast:-1:(ilast-k+1)  # indices of all non-zero B-splines at x
 
         @testset "Evaluate single" for (b, i) ∈ zip(bs, iall)
             @test B[i](x) ≈ b
-            @test B[i - N](x - L) ≈ b  # periodicity
-            @test B[i + N](x + L) ≈ b  # periodicity
+            @test B[i-N](x - L) ≈ b  # periodicity
+            @test B[i+N](x + L) ≈ b  # periodicity
         end
 
         @testset "Support" for i ∈ eachindex(B)
@@ -91,8 +101,8 @@ function test_periodic_splines(ord::BSplineOrder)
         end
 
         @testset "Approximations" begin
-            @test isapprox(app_in(x), ftest(x); rtol = 0.01)
-            @test isapprox(app_L2(x), ftest(x); rtol = 0.01)
+            @test isapprox(app_in(x), ftest(x); rtol=0.01)
+            @test isapprox(app_L2(x), ftest(x); rtol=0.01)
         end
     end
 
@@ -100,15 +110,15 @@ function test_periodic_splines(ord::BSplineOrder)
     # (except for the knot index, which is shifted).
     @testset "Compare to regular" begin
         Bn = BSplineBasis(ord, breaks)
-        x = (2 * breaks[k + 2] + breaks[k + 3]) / 3
-        x′ = (3 * breaks[k + 3] + breaks[k + 4]) / 4  # for integrals
+        x = (2 * breaks[k+2] + breaks[k+3]) / 3
+        x′ = (3 * breaks[k+3] + breaks[k+4]) / 4  # for integrals
 
         # Index offset for matching regular to periodic basis
         δ = (order(B) - 1) - BSplines.index_offset(knots(B))
 
         @testset "B-spline evaluation: $op" for op ∈ (
-                Derivative(0), Derivative(1), Derivative(2),
-            )
+            Derivative(0), Derivative(1), Derivative(2),
+        )
             iₙ, bsₙ = Bn(x, op)  # B-splines from regular ("normal") basis
             iₚ, bsₚ = B(x, op)   # B-splines from periodic basis
             @test iₙ == iₚ + δ  # knot indices are shifted
@@ -119,7 +129,7 @@ function test_periodic_splines(ord::BSplineOrder)
             coefs = randn(rng, length(Bn))
             Sn = Spline(Bn, coefs)
             Sp = Spline{Float64}(undef, B)
-            coefficients(Sp) .= @view coefs[(δ + 1):(δ + length(Sp))]
+            coefficients(Sp) .= @view coefs[(δ+1):(δ+length(Sp))]
             @test Sn(x) == Sp(x)
             @test (Derivative(1) * Sn)(x) == (Derivative(1) * Sp)(x)
             @test (Derivative(2) * Sn)(x) == (Derivative(2) * Sp)(x)
@@ -131,10 +141,10 @@ function test_periodic_splines(ord::BSplineOrder)
 
     @testset "Collocation + interpolation" begin
         xs = @inferred collocation_points(B)
-        @test iseven(k) == (xs == breaks)  # this is the default for even k
+        @test iseven(k) == (xs == breaks[begin:end-1])  # this is the default for even k
         C = @inferred collocation_matrix(B, xs)
         @test cond(Array(C)) < 1e3
-        @test all(≈(1), sum(C; dims = 2))  # partition of unity
+        @test all(≈(1), sum(C; dims=2))  # partition of unity
 
         # Interpolate manually
         ys = ftest.(xs)
@@ -159,7 +169,7 @@ function test_periodic_splines(ord::BSplineOrder)
         # Similarly, the sum along each column (or row) is
         #       ∫ b_j dx = (t[j + k] - t[j]) / k
         @test all(axes(G, 2)) do j
-            sum(view(G, :, j)) ≈ (ts[j + k] - ts[j]) / k
+            sum(view(G, :, j)) ≈ (ts[j+k] - ts[j]) / k
         end
     end
 


### PR DESCRIPTION
This PR changes the constructor of `PeriodicBSplineBasis` so that the period `L` is no longer required. Instead, the given knot vector must *include* the endpoint, which allows to determine `L`.

The old constructor still works but now shows a deprecation warning.