### PR TITLE
Fix deprecated Vararg syntax

### DIFF
--- a/src/Galerkin/linear.jl
+++ b/src/Galerkin/linear.jl
@@ -178,7 +178,7 @@ galerkin_matrix!(M, B::AbstractBSplineBasis, args...) =
     galerkin_matrix!(M, (B, B), args...)
 
 function galerkin_matrix!(
-        S::AbstractMatrix, Bs::Tuple{Vararg{<:AbstractBSplineBasis,2}},
+        S::AbstractMatrix, Bs::Tuple{Vararg{AbstractBSplineBasis,2}},
         deriv = Derivative.((0, 0)),
     )
     _check_bases(Bs)


### PR DESCRIPTION
The package errors currently when loaded with `--depwarn=error`, and this should fix the error that is indicated. There might be other deprecated code that needs fixing.