### PR TITLE
Fix odd-order periodic interpolations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSplineKit"
 uuid = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com>"]
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -17,7 +17,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 ArrayLayouts = "0.8"
 BandedMatrices = "0.17"
-FastGaussQuadrature = "0.4, 0.5"
+FastGaussQuadrature = "0.5"
 LazyArrays = "0.22"
 Reexport = "1.0"
 StaticArrays = "1.0"

--- a/src/BSplines/periodic.jl
+++ b/src/BSplines/periodic.jl
@@ -54,26 +54,6 @@ struct PeriodicKnots{T, k, Knots <: AbstractVector{T}} <: AbstractPeriodicVector
     end
 end
 
-# This undocumented constructor is for compatibility with previous versions,
-# and may be removed soon.
-# Note that, here, the endpoint shound *not* be included in the knot vector.
-function PeriodicKnots(breaks::AbstractVector{T}, period::Real, ord::BSplineOrder) where {T}
-    @warn """The constructor PeriodicKnots(breaks, period, order) is deprecated.
-    Use PeriodicKnots(breaks, order) instead, and include the endpoint in the `breaks` vector.
-    """
-    a = first(breaks)
-    b = a + period
-    if last(breaks) ≥ b
-        throw(
-            ArgumentError(
-                "the knot extent (t[end] - t[begin]) must be *strictly* smaller than the period L",
-            )
-        )
-    end
-    ts = vcat(breaks, b)
-    PeriodicKnots(ts, ord)
-end
-
 boundaries(ts::PeriodicKnots) = ts.boundaries
 period(ts::PeriodicKnots) = ts.period
 order(::PeriodicKnots{T, k}) where {T, k} = k

--- a/test/periodic.jl
+++ b/test/periodic.jl
@@ -11,12 +11,7 @@ function test_periodic_splines(ord::BSplineOrder)
 
     # Test deprecated constructors
     @testset "Deprecated" begin
-        @test_logs(
-            (:warn, r"The constructor PeriodicKnots\(.*\) is deprecated"),
-            BSplineKit.PeriodicKnots(breaks[1:end-1], L, ord),
-        )
-        @test_throws ArgumentError BSplineKit.PeriodicKnots(breaks, L, ord)
-        @test B == @test_deprecated PeriodicBSplineBasis(ord, breaks[begin:end-1], L)
+        @test_deprecated PeriodicBSplineBasis(ord, breaks[begin:end-1], L)
     end
 
     N = length(B)
@@ -31,7 +26,7 @@ function test_periodic_splines(ord::BSplineOrder)
     @test typeof(period(B)) === eltype(breaks)
     @test @inferred(boundaries(B)) == (0, 1)
     @test B == B
-    let B′ = PeriodicBSplineBasis(BSplineOrder(k - 1), breaks, L)
+    let B′ = PeriodicBSplineBasis(BSplineOrder(k - 1), breaks)
         @test B ≠ B′
     end
 
@@ -108,8 +103,8 @@ function test_periodic_splines(ord::BSplineOrder)
 
     # Far from the boundaries, the result should match a regular BSplineBasis
     # (except for the knot index, which is shifted).
+    Bn = BSplineBasis(ord, breaks)
     @testset "Compare to regular" begin
-        Bn = BSplineBasis(ord, breaks)
         x = (2 * breaks[k+2] + breaks[k+3]) / 3
         x′ = (3 * breaks[k+3] + breaks[k+4]) / 4  # for integrals
 


### PR DESCRIPTION
Also, remove deprecated `PeriodicBSplineBasis` constructor.