### PR TITLE
Workaround precompilation issue

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSplineKit"
 uuid = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 authors = ["Juan Ignacio Polanco <jipolanc@gmail.com>"]
-version = "0.14.3"
+version = "0.14.4"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/BSplineKit.jl
+++ b/src/BSplineKit.jl
@@ -52,8 +52,9 @@ include("SplineExtrapolations/SplineExtrapolations.jl")
             S = Spline(B, rand(length(B)))
             S(0.32)
             Derivative() * S
-            interpolate(xdata, ydata, ord)
-            iseven(order(ord)) && interpolate(xdata, ydata, ord, Natural())
+            # FIXME precompilation sometimes fails here (see e.g. issue #58):
+            # interpolate(xdata, ydata, ord)
+            # iseven(order(ord)) && interpolate(xdata, ydata, ord, Natural())
             approximate(sinpi, B, MinimiseL2Error())  # triggers compilation of Galerkin stuff
         end
     end


### PR DESCRIPTION
For some reason, precompilation with SnoopPrecompile sometimes fails on `interpolate`.

Closes #58.