### PR TITLE
Use custom LazyVcatVector instead of LazyArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,12 @@
 name = "BSplineKit"
 uuid = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 authors = ["Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr>"]
-version = "0.16.3"
+version = "0.16.4"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
-LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -21,7 +20,6 @@ StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 ArrayLayouts = "1"
 BandedMatrices = "0.17"
 FastGaussQuadrature = "0.5"
-LazyArrays = "1"
 Reexport = "1.0"
 PrecompileTools = "1.0"
 Static = "0.8"

--- a/src/Recombinations/splines.jl
+++ b/src/Recombinations/splines.jl
@@ -1,4 +1,24 @@
-using LazyArrays: ApplyArray
+# This is similar to LazyArrays.ApplyArray(vcat, ...) but without the extra allocations.
+struct LazyVcatVector{T, Data <: Tuple{Vararg{AbstractVector}}} <: AbstractVector{T}
+    data   :: Data
+    length :: Int
+    function LazyVcatVector(data::Tuple)
+        T = Base.promote_eltype(data...)
+        foreach(Base.require_one_based_indexing, data)
+        n = sum(length, data)
+        new{T, typeof(data)}(data, n)
+    end
+end
+
+LazyVcatVector(args...) = LazyVcatVector(args)
+
+Base.size(v::LazyVcatVector) = (v.length,)
+
+Base.@propagate_inbounds Base.getindex(v::LazyVcatVector, i::Integer) = _getindex(v, i, i, v.data...)
+Base.@propagate_inbounds _getindex(v, i, j, u, etc...) = j ≤ length(u) ? u[j] : _getindex(v, i, j - length(u), etc...)
+@inline _getindex(v, i, j) = throw(BoundsError(v, i))
+
+## ================================================================================ ##
 
 """
     parent_coefficients(R::RecombinedBSplineBasis, coefs::AbstractVector)
@@ -7,7 +27,7 @@ Returns the coefficients associated to the parent B-spline basis, from the
 coefficients `coefs` in the recombined basis.
 
 Note that this function doesn't allocate, since it returns a lazy concatenation
-(via LazyArrays.jl) of two StaticArrays and a view of the `coefs` vector.
+of two StaticArrays and a view of the `coefs` vector.
 """
 function parent_coefficients(R::RecombinedBSplineBasis, coefs::AbstractVector)
     length(coefs) == length(R) ||
@@ -32,7 +52,7 @@ function parent_coefficients(R::RecombinedBSplineBasis, coefs::AbstractVector)
     yB = @inbounds view(coefs, (Na + 1):H)
     yC = C * xC
 
-    ApplyArray(vcat, yA, yB, yC)
+    LazyVcatVector(yA, yB, yC)
 end
 
 # Returns spline written in the parent basis (usually a regular BSplineBasis).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,13 +6,13 @@ using Random
 using SparseArrays
 using Test
 
-import BSplineKit:
+using BSplineKit:
     AbstractDifferentialOp,
     DifferentialOpSum,
     LeftNormal,
     RightNormal
 
-import BSplineKit.Recombinations:
+using BSplineKit.Recombinations:
     NoUniqueSolutionError,
     num_constraints,
     num_recombined


### PR DESCRIPTION
This fixes allocation tests. It seems like some recent version of LazyArrays results in extra allocations when constructing a lazy array as in `ApplyArray(vcat, x, y, z)`. It's not the first time this happens, so we define a minimal custom type instead...