### PR TITLE
Make `Spline` a subtype of `Function`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BSplineKit"
 uuid = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 authors = ["Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr>"]
-version = "0.17.1"
+version = "0.17.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Documenter = "1"
-Makie = "0.19"
+Makie = "0.20"
 
 [extras]
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"

--- a/examples/approximation.jl
+++ b/examples/approximation.jl
@@ -9,13 +9,13 @@
 # ``x ∈ [0, 1]``.
 
 using CairoMakie
-CairoMakie.activate!(type = "svg")
+CairoMakie.activate!(type = "svg", pt_per_unit = 2.0)
 
 x_interval = 0..1
 f(x) = exp(-x) * cospi(8x)
 
-fig = Figure(resolution = (800, 600))
-ax = Axis(fig[1, 1]; xlabel = "x")
+fig = Figure()
+ax = Axis(fig[1, 1]; xlabel = rich("x"; font = :italic))
 lines!(ax, x_interval, f)
 fig
 
@@ -73,8 +73,12 @@ function plot_basis!(ax, B; eval_args = (), kws...)
     ax
 end
 
-fig = Figure(resolution = (800, 600))
-ax = Axis(fig[1, 1]; xlabel = "x", ylabel = "bᵢ(x)")
+fig = Figure()
+ax = Axis(
+    fig[1, 1];
+    xlabel = rich("x"; font = :italic),
+    ylabel = rich("b", subscript("i"), rich("(x)"; offset = (0.1, 0.0)); font = :italic),
+)
 plot_basis!(ax, B; knot_offset = 0.05)
 fig
 
@@ -175,17 +179,17 @@ S_minL2 = approximate(f, B, MinimiseL2Error())
 # Below, the approximations using the three methods are compared to the actual
 # function ``f``.
 
-fig = Figure(resolution = (1000, 750))
+fig = Figure(size = (950, 750))
 colours = theme(fig.scene).palette.color[]
 style_vd = (color = colours[3], label = "Variation diminishing")
 style_interp = (color = colours[2], label = "Interpolation")
 style_minL2 = (color = colours[1], label = "L² minimisation")
-let ax = Axis(fig[1:2, 1]; xlabel = "x", ylabel = "Approximation")
+let ax = Axis(fig[1:2, 1]; xlabel = rich("x"; font = :italic), ylabel = "Approximation")
     plot_knots!(ax, knots(B); knot_offset = nothing)
     lines!(ax, x_interval, f; color = :black, linewidth = 2, label = "Original")
-    lines!(ax, x_interval, x -> S_vd(x); style_vd...)
-    lines!(ax, x_interval, x -> S_interp(x); style_interp...)
-    lines!(ax, x_interval, x -> S_minL2(x); style_minL2...)
+    lines!(ax, x_interval, S_vd; style_vd...)
+    lines!(ax, x_interval, S_interp; style_interp...)
+    lines!(ax, x_interval, S_minL2; style_minL2...)
     axislegend(ax)
 end
 let ax = Axis(fig[1, 2]; ylabel = "Difference with original")
@@ -195,7 +199,7 @@ let ax = Axis(fig[1, 2]; ylabel = "Difference with original")
     hidexdecorations!(ax; grid = false)
     axislegend(ax; position = :rt, orientation = :horizontal)
 end
-let ax = Axis(fig[2, 2]; xlabel = "x", ylabel = "Squared difference", yscale = log10)
+let ax = Axis(fig[2, 2]; xlabel = rich("x"; font = :italic), ylabel = "Squared difference", yscale = log10)
     ylims!(1e-8, 1e-2)
     plot_knots!(ax, knots(B); knot_offset = nothing, ybase = 1e-6)
     lines!(ax, x_interval, x -> abs2(S_interp(x) - f(x)); style_interp...)

--- a/examples/interpolation.jl
+++ b/examples/interpolation.jl
@@ -31,14 +31,14 @@ S = interpolate(xs, ys, BSplineOrder(4))
 
 # Let's plot the result:
 
-lines!(0..1, x -> S(x); label = "k = 4", color = Cycled(4 - 3))
+lines!(0..1, S; label = "k = 4", color = Cycled(4 - 3))
 current_figure()  # hide
 
 # We can also choose other interpolation orders for comparison:
 
 for k ∈ (5, 6, 8)
     S = interpolate(xs, ys, BSplineOrder(k))
-    lines!(0..1, x -> S(x); label = "k = $k", color = Cycled(k - 3))
+    lines!(0..1, S; label = "k = $k", color = Cycled(k - 3))
 end
 axislegend()
 current_figure()  # hide
@@ -78,8 +78,8 @@ Snat = interpolate(xs, ys, BSplineOrder(k), Natural())  # with natural BCs
 # Let's look at the result:
 
 scatter(xs, ys; label = "Data", color = :black)
-lines!(0..1, x -> S(x); label = "k = $k (original)", linewidth = 2)
-lines!(0..1, x -> Snat(x); label = "k = $k (natural)", linestyle = :dash, linewidth = 4)
+lines!(0..1, S; label = "k = $k (original)", linewidth = 2)
+lines!(0..1, Snat; label = "k = $k (natural)", linestyle = :dash, linewidth = 4)
 axislegend()
 current_figure()  # hide
 
@@ -114,12 +114,12 @@ E_smooth = extrapolate(S, Smooth())
 
 #
 
-fig = Figure(resolution = (600, 400))
+fig = Figure(size = (600, 400))
 ax = Axis(fig[1, 1])
 scatter!(ax, xs, ys; label = "Data", color = :black)
-lines!(ax, -0.5..1.5, x -> S(x); label = "No extrapolation", linewidth = 2)
-lines!(ax, -0.5..1.5, x -> E_smooth(x); label = "Smooth", linestyle = :dash, linewidth = 2)
-lines!(ax, -0.5..1.5, x -> E_flat(x); label = "Flat", linestyle = :dot, linewidth = 2)
+lines!(ax, -0.5..1.5, S; label = "No extrapolation", linewidth = 2)
+lines!(ax, -0.5..1.5, E_smooth; label = "Smooth", linestyle = :dash, linewidth = 2)
+lines!(ax, -0.5..1.5, E_flat; label = "Flat", linestyle = :dot, linewidth = 2)
 axislegend(ax)
 fig
 

--- a/src/SplineApproximations/SplineApproximations.jl
+++ b/src/SplineApproximations/SplineApproximations.jl
@@ -48,7 +48,7 @@ method(a::SplineApproximation) = a.method
 SplineInterpolations.spline(a::SplineApproximation) = a.spline
 data(a::SplineApproximation) = a.data
 
-function Base.show(io::IO, A::SplineApproximation)
+function Base.show(io::IO, ::MIME"text/plain", A::SplineApproximation)
     print(io, nameof(typeof(A)), " containing the ", spline(A))
     print(io, "\n approximation method: ", method(A))
     nothing
@@ -76,7 +76,6 @@ This completely avoids allocations and strongly reduces computation time.
 
 ```jldoctest
 julia> B = BSplineBasis(BSplineOrder(3), -1:0.4:1);
-
 
 julia> S_interp = approximate(sin, B)
 SplineApproximation containing the 7-element Spline{Float64}:

--- a/src/SplineExtrapolations/SplineExtrapolations.jl
+++ b/src/SplineExtrapolations/SplineExtrapolations.jl
@@ -69,7 +69,7 @@ method(f::SplineExtrapolation) = f.method
 
 SplineExtrapolation(S::SplineWrapper, args...) = SplineExtrapolation(spline(S), args...)
 
-function Base.show(io::IO, f::SplineExtrapolation)
+function Base.show(io::IO, ::MIME"text/plain", f::SplineExtrapolation)
     println(io, nameof(typeof(f)), " containing the ", spline(f))
     let io = IOContext(io, :compact => true, :limit => true)
         print(io, " extrapolation method: ", method(f))

--- a/src/SplineInterpolations/SplineInterpolations.jl
+++ b/src/SplineInterpolations/SplineInterpolations.jl
@@ -111,7 +111,7 @@ interpolation_points(S::SplineInterpolation) = S.x
 SplineInterpolation(init, B, x::AbstractVector) =
     SplineInterpolation(init, B, x, eltype(x))
 
-function Base.show(io::IO, I::SplineInterpolation)
+function Base.show(io::IO, ::MIME"text/plain", I::SplineInterpolation)
     println(io, nameof(typeof(I)), " containing the ", spline(I))
     let io = IOContext(io, :compact => true, :limit => true)
         println(io, " interpolation points: ", interpolation_points(I))

--- a/src/Splines/spline.jl
+++ b/src/Splines/spline.jl
@@ -70,7 +70,7 @@ Broadcast.broadcastable(S::Spline) = Ref(S)
 
 Base.copy(S::Spline) = Spline(basis(S), copy(coefficients(S)))
 
-function Base.show(io::IO, S::Spline)
+function Base.show(io::IO, ::MIME"text/plain", S::Spline)
     println(io, length(S), "-element ", nameof(typeof(S)), '{', eltype(S), '}', ':')
     print(io, " basis: ")
     summary(io, basis(S))
@@ -81,6 +81,8 @@ function Base.show(io::IO, S::Spline)
     end
     nothing
 end
+
+Base.show(io::IO, S::Spline) = show(io, MIME("text/plain"), S)
 
 Base.:(==)(P::Spline, Q::Spline) =
     basis(P) == basis(Q) && coefficients(P) == coefficients(Q)

--- a/src/Splines/spline.jl
+++ b/src/Splines/spline.jl
@@ -1,7 +1,7 @@
 using StaticArrays: MVector
 
 """
-    Spline{T}
+    Spline{T} <: Function
 
 Represents a spline function.
 
@@ -42,7 +42,7 @@ struct Spline{
         T,  # type of coefficient (e.g. Float64, ComplexF64)
         Basis <: AbstractBSplineBasis,
         CoefVector <: AbstractVector{T},
-    }
+    } <: Function
     basis :: Basis
     coefs :: CoefVector
 

--- a/src/Splines/wrapper.jl
+++ b/src/Splines/wrapper.jl
@@ -15,6 +15,8 @@ Returns the [`Spline`](@ref) wrapped by the object.
 """
 spline(w::SplineWrapper) = w.spline
 
+Base.show(io::IO, S::SplineWrapper) = show(io, MIME("text/plain"), S)
+
 Base.eltype(::Type{<:SplineWrapper{S}}) where {S} = eltype(S)
 
 (I::SplineWrapper)(x) = spline(I)(x)

--- a/src/Splines/wrapper.jl
+++ b/src/Splines/wrapper.jl
@@ -1,12 +1,12 @@
 """
-    SplineWrapper{S <: Spline}
+    SplineWrapper{S <: Spline} <: Function
 
 Abstract type representing a type that wraps a [`Spline`](@ref).
 
 Such a type implements all common operations on splines, including evaluation,
 differentiation, etc…
 """
-abstract type SplineWrapper{S <: Spline} end
+abstract type SplineWrapper{S <: Spline} <: Function end
 
 """
     spline(w::SplineWrapper) -> Spline


### PR DESCRIPTION
Same for `SplineWrapper`.

This allows to use splines where a `Function` is expected.

One example is for plots with Makie. Instead of doing:

```julia
lines!(ax, 0..3, x -> S(x))
```

we can now simply do:

```julia
lines!(ax, 0..3, S)
```

for a spline `S`.